### PR TITLE
Simplify WordPress test config for wp-phpunit harness

### DIFF
--- a/wp-tests-config.php
+++ b/wp-tests-config.php
@@ -3,45 +3,16 @@
  * WordPress test suite configuration file.
  */
 
-// Load environment variables from a .env file if present
-$env_file = __DIR__ . '/.env';
-if (file_exists( $env_file ) ) {
-    $env = parse_ini_file( $env_file, false, INI_SCANNER_RAW );
-    if ( is_array( $env ) ) {
-        foreach ( $env as $key => $value ) {
-            if ( getenv( $key ) === false ) {
-                putenv( "$key=$value" );
-                $_ENV[ $key ] = $value;
-            }
-        }
-    }
-}
-
-// DB settings for your test database
-define( 'DB_NAME', getenv( 'DB_NAME' ) ?: 'wordpress_test' );
-define( 'DB_USER', getenv( 'DB_USER' ) ?: 'root' );
-define( 'DB_PASSWORD', getenv( 'DB_PASSWORD' ) ?: 'root' );
-define( 'DB_HOST', getenv( 'DB_HOST' ) ?: '127.0.0.1' );
-define( 'DB_CHARSET', 'utf8mb4' );
+define( 'DB_NAME', 'wp_phpunit_tests' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', '' );
+define( 'DB_HOST', '127.0.0.1' );
+define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 
-// Site constants required by WP test suite
-define( 'WP_TESTS_DOMAIN', 'example.org' );
-define( 'WP_TESTS_EMAIL', 'admin@example.org' );
-define( 'WP_TESTS_TITLE', 'Test Blog' );
+$table_prefix = 'wptests_';
 
-// PHP binary for running tests
-define( 'WP_PHP_BINARY', 'php' );
+define( 'WP_TESTS_MULTISITE', false );
+define( 'WP_DEBUG', true );
+define( 'DISABLE_WP_CRON', true );
 
-// Path to WordPress source; honor WP_CORE_DIR when provided
-$wp_core_dir = getenv( 'WP_CORE_DIR' );
-if ( ! $wp_core_dir ) {
-    $wp_core_dir = dirname( __FILE__ ) . '/wordpress';
-}
-
-$wp_core_dir = rtrim( $wp_core_dir, '/\\' ) . '/';
-
-define( 'ABSPATH', $wp_core_dir );
-
-// Bootstrap the WordPress environment for testing
-require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
## Summary
- replace the test configuration with the wp-phpunit defaults so the package controls the bootstrap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c4c86bb8832eb71e8d5e61cf5843