### PR TITLE
Update PHPUnit configuration for new defaults

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,14 +28,15 @@
 
     <php>
         <!-- Path to Composer-installed WP PHPUnit test suite -->
-        <env name="WP_TESTS_DIR" value="vendor/wp-phpunit/wp-phpunit"/>
-        <!-- Path to WP core for tests if needed -->
-        <env name="WP_CORE_DIR" value="/tmp/wordpress"/>
+        <env name="WP_PHPUNIT__DIR" value="vendor/wp-phpunit/wp-phpunit"/>
 
         <!-- Database credentials for test environment -->
-        <env name="DB_NAME" value="wordpress_test"/>
+        <env name="DB_NAME" value="wp_phpunit_tests"/>
         <env name="DB_USER" value="root"/>
-        <env name="DB_PASSWORD" value="root"/>
-        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PASSWORD" value=""/>
+        <env name="DB_HOST" value="localhost"/>
+
+        <!-- Optional: add secrets required by tests, e.g. -->
+        <!-- <env name="API_TOKEN" value=""/> -->
     </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- point PHPUnit to the WP PHP unit harness via WP_PHPUNIT__DIR and clean up unused WP core override
- align test database environment variables with the current default values and provide a placeholder for secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c4da4314832ebb39e637d974388c