### PR TITLE
Adjust CI workflow to create WordPress test database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     env:
       WP_VERSION: ${{ matrix.wp-version }}
-      DB_NAME: wordpress_test
+      DB_NAME: wp_phpunit_tests
       DB_USER: root
       DB_PASSWORD: root
       DB_HOST: 127.0.0.1
@@ -96,8 +96,8 @@ jobs:
       - name: Run PHPCS Sniff
         run: composer run sniff
 
-      - name: Setup WordPress test suite
-        run: bash ./scripts/src/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASSWORD $DB_HOST ${{ matrix.wp-version }}
+      - name: Prepare test database
+        run: mysql -h "$DB_HOST" -u"$DB_USER" -p"$DB_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
       - name: Run PHPUnit tests
         run: |


### PR DESCRIPTION
## Summary
- update the test job database name to match the new configuration
- replace the WordPress test suite install script with an inline database creation step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c58518bc832e89bb5d2a8691c228