### PR TITLE
Update engagement dashboard role filters and post types

### DIFF
--- a/src/Admin/EngagementDashboard.php
+++ b/src/Admin/EngagementDashboard.php
@@ -43,7 +43,7 @@ class EngagementDashboard
         $per_page = 20;
 
         $all_users = get_users([
-            'role__in' => ['subscriber', 'artpulse_member', 'artpulse_pro', 'artpulse_org'],
+            'role__in' => ['subscriber', 'member', 'artist', 'organization'],
             'orderby'  => 'registered',
             'order'    => 'DESC',
             'number'   => 9999,
@@ -52,8 +52,8 @@ class EngagementDashboard
         $filtered = [];
         foreach ($all_users as $user) {
             $last_login = get_user_meta($user->ID, 'wp_last_login', true);
-            $artworks = count_user_posts($user->ID, 'artwork');
-            $events = count_user_posts($user->ID, 'event');
+            $artworks = count_user_posts($user->ID, 'artpulse_artwork');
+            $events = count_user_posts($user->ID, 'artpulse_event');
             $activity_score = $artworks + $events;
 
             $is_active = strtotime($last_login) > strtotime('-30 days') || $activity_score > 0;


### PR DESCRIPTION
## Summary
- align the engagement dashboard member query with the member, artist, and organization role slugs registered by RoleSetup
- count artwork and event activity using the artpulse_artwork and artpulse_event post types so tables, scores, and CSV exports match registered content types

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0dc0118d4832eb1ebed44dea7ad77