### PR TITLE
Fix core module requires in community REST e2e test

### DIFF
--- a/tests/e2e/community-rest.spec.js
+++ b/tests/e2e/community-rest.spec.js
@@ -1,6 +1,6 @@
-const { execFile } = require('node:child_process');
-const { promisify } = require('node:util');
-const crypto = require('node:crypto');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const crypto = require('crypto');
 
 const execFileAsync = promisify(execFile);
 const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';


### PR DESCRIPTION
## Summary
- update the community REST E2E spec to require core modules without the `node:` prefix so Jest detects them correctly

## Testing
- npm run test:e2e:community *(fails: Chromium download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0df4f0e5c832e8c993fe8a96d29de