### PR TITLE
Fix org dashboard capability checks and add admin selector tests

### DIFF
--- a/src/Admin/OrgDashboardAdmin.php
+++ b/src/Admin/OrgDashboardAdmin.php
@@ -24,7 +24,7 @@ class OrgDashboardAdmin
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('Organization Dashboard', 'artpulse') . '</h1>';
 
-        if (current_user_can('administrator')) {
+        if (current_user_can('manage_options')) {
             self::render_org_selector();
         }
 
@@ -38,8 +38,13 @@ class OrgDashboardAdmin
 
     private static function get_current_org_id(): int
     {
-        if (current_user_can('administrator')) {
+        if (current_user_can('manage_options')) {
             $selected = filter_input(INPUT_GET, 'org_id', FILTER_SANITIZE_NUMBER_INT);
+
+            if (null === $selected) {
+                $selected = $_GET['org_id'] ?? null;
+            }
+
             if (null !== $selected && '' !== $selected) {
                 return absint($selected);
             }

--- a/tests/Admin/OrgDashboardAdminTest.php
+++ b/tests/Admin/OrgDashboardAdminTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ArtPulse\Tests\Admin;
+
+use ArtPulse\Admin\OrgDashboardAdmin;
+use WP_UnitTestCase;
+
+class OrgDashboardAdminTest extends WP_UnitTestCase
+{
+    private int $adminId;
+    private int $managerId;
+    private int $orgOne;
+    private int $orgTwo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        do_action('init');
+
+        if (!get_role('organization')) {
+            add_role('organization', 'Organization', ['read' => true]);
+        }
+
+        $this->adminId   = self::factory()->user->create(['role' => 'administrator']);
+        $this->managerId = self::factory()->user->create(['role' => 'organization']);
+
+        $this->orgOne = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_title'  => 'Org One',
+            'post_status' => 'publish',
+        ]);
+
+        $this->orgTwo = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_title'  => 'Org Two',
+            'post_status' => 'publish',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        wp_set_current_user(0);
+        unset($_GET['org_id']);
+        putenv('QUERY_STRING');
+    }
+
+    public function test_site_administrator_sees_selector_and_can_switch_org_context(): void
+    {
+        wp_set_current_user($this->adminId);
+        $_GET = [];
+        putenv('QUERY_STRING');
+
+        ob_start();
+        OrgDashboardAdmin::render();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('id="ap-org-select"', $output);
+        $this->assertStringContainsString((string) $this->orgOne, $output);
+        $this->assertStringContainsString((string) $this->orgTwo, $output);
+
+        $_GET['org_id'] = (string) $this->orgTwo;
+        putenv('QUERY_STRING=page=ap-org-dashboard&org_id=' . $this->orgTwo);
+
+        $this->assertSame($this->orgTwo, $this->callGetCurrentOrgId());
+    }
+
+    public function test_org_manager_does_not_see_selector_and_cannot_change_context(): void
+    {
+        wp_set_current_user($this->managerId);
+        update_user_meta($this->managerId, 'ap_org_id', $this->orgOne);
+
+        ob_start();
+        OrgDashboardAdmin::render();
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('id="ap-org-select"', $output);
+
+        $_GET['org_id'] = (string) $this->orgTwo;
+        putenv('QUERY_STRING=page=ap-org-dashboard&org_id=' . $this->orgTwo);
+
+        $this->assertSame($this->orgOne, $this->callGetCurrentOrgId());
+    }
+
+    private function callGetCurrentOrgId(): int
+    {
+        $method = new \ReflectionMethod(OrgDashboardAdmin::class, 'get_current_org_id');
+        $method->setAccessible(true);
+
+        return (int) $method->invoke(null);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the org dashboard administrator check with the `manage_options` capability and fall back to `$_GET` when no filtered value is available
- ensure administrators can change organization context while managers continue using their assigned organization
- add PHPUnit coverage verifying the selector is shown to site admins and hidden from non-admin managers

## Testing
- composer test *(fails: vendor/bin/phpunit not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0eb9f4744832ead4840b1afb93be3