### PR TITLE
Support new organization meta key in dashboard

### DIFF
--- a/src/Admin/OrgDashboardAdmin.php
+++ b/src/Admin/OrgDashboardAdmin.php
@@ -59,7 +59,15 @@ class OrgDashboardAdmin
             return $orgs ? absint($orgs[0]->ID) : 0;
         }
 
-        return (int) get_user_meta(get_current_user_id(), 'ap_org_id', true);
+        $user_id = get_current_user_id();
+
+        $org_id = get_user_meta($user_id, 'ap_organization_id', true);
+
+        if ('' === $org_id || null === $org_id) {
+            $org_id = get_user_meta($user_id, 'ap_org_id', true);
+        }
+
+        return (int) $org_id;
     }
 
     private static function render_org_selector(): void

--- a/tests/Admin/OrgDashboardAdminTest.php
+++ b/tests/Admin/OrgDashboardAdminTest.php
@@ -45,6 +45,8 @@ class OrgDashboardAdminTest extends WP_UnitTestCase
         wp_set_current_user(0);
         unset($_GET['org_id']);
         putenv('QUERY_STRING');
+        delete_user_meta($this->managerId, 'ap_organization_id');
+        delete_user_meta($this->managerId, 'ap_org_id');
     }
 
     public function test_site_administrator_sees_selector_and_can_switch_org_context(): void
@@ -70,7 +72,7 @@ class OrgDashboardAdminTest extends WP_UnitTestCase
     public function test_org_manager_does_not_see_selector_and_cannot_change_context(): void
     {
         wp_set_current_user($this->managerId);
-        update_user_meta($this->managerId, 'ap_org_id', $this->orgOne);
+        update_user_meta($this->managerId, 'ap_organization_id', $this->orgOne);
 
         ob_start();
         OrgDashboardAdmin::render();
@@ -82,6 +84,62 @@ class OrgDashboardAdminTest extends WP_UnitTestCase
         putenv('QUERY_STRING=page=ap-org-dashboard&org_id=' . $this->orgTwo);
 
         $this->assertSame($this->orgOne, $this->callGetCurrentOrgId());
+    }
+
+    public function test_org_manager_with_legacy_meta_key_is_still_supported(): void
+    {
+        wp_set_current_user($this->managerId);
+        update_user_meta($this->managerId, 'ap_org_id', $this->orgTwo);
+
+        $_GET = [];
+        putenv('QUERY_STRING');
+
+        $this->assertSame($this->orgTwo, $this->callGetCurrentOrgId());
+    }
+
+    public function test_org_manager_with_org_meta_sees_assigned_data(): void
+    {
+        wp_set_current_user($this->managerId);
+        update_user_meta($this->managerId, 'ap_organization_id', $this->orgOne);
+
+        $linkedArtist = self::factory()->post->create([
+            'post_type'   => 'ap_profile_link',
+            'post_status' => 'publish',
+        ]);
+        update_post_meta($linkedArtist, 'org_id', $this->orgOne);
+        update_post_meta($linkedArtist, 'status', 'approved');
+        update_post_meta($linkedArtist, 'artist_user_id', 123);
+        update_post_meta($linkedArtist, 'requested_on', '2024-01-01');
+
+        $artwork = self::factory()->post->create([
+            'post_type'   => 'artpulse_artwork',
+            'post_title'  => 'Sunset Vista',
+            'post_status' => 'publish',
+        ]);
+        update_post_meta($artwork, 'org_id', $this->orgOne);
+        update_post_meta($artwork, 'ap_views', 42);
+        update_post_meta($artwork, 'ap_favorites', 7);
+
+        $event = self::factory()->post->create([
+            'post_type'   => 'artpulse_event',
+            'post_title'  => 'Annual Gala',
+            'post_status' => 'publish',
+        ]);
+        update_post_meta($event, 'org_id', $this->orgOne);
+
+        update_post_meta($this->orgOne, 'stripe_payment_ids', ['ch_12345']);
+
+        ob_start();
+        OrgDashboardAdmin::render();
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('No organisation assigned to your user.', $output);
+        $this->assertStringContainsString('Linked Artists', $output);
+        $this->assertStringContainsString('123', $output);
+        $this->assertStringContainsString('Sunset Vista', $output);
+        $this->assertStringContainsString('Annual Gala', $output);
+        $this->assertStringContainsString('Total Artwork Views', $output);
+        $this->assertStringContainsString('Charge ID', $output);
     }
 
     private function callGetCurrentOrgId(): int


### PR DESCRIPTION
## Summary
- resolve organization context for managers via the new ap_organization_id meta key with legacy fallback
- expand OrgDashboardAdmin tests to cover the new meta key, ensure legacy support, and confirm dashboards surface linked data

## Testing
- composer test *(fails: vendor/bin/phpunit missing because composer install requires GitHub access and returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ed20b330832e921228813df24fb9