### PR TITLE
Add admin dashboard asset enqueue

### DIFF
--- a/src/Core/RoleDashboards.php
+++ b/src/Core/RoleDashboards.php
@@ -43,8 +43,28 @@ class RoleDashboards
         }
 
         add_action('wp_enqueue_scripts', [self::class, 'enqueueAssets']);
+        add_action('admin_enqueue_scripts', [self::class, 'enqueueDashboardAssets']);
         add_action('rest_api_init', [self::class, 'registerRoutes']);
         add_action('wp_dashboard_setup', [self::class, 'registerDashboardWidgets']);
+    }
+
+    public static function enqueueDashboardAssets(): void
+    {
+        if (!function_exists('get_current_screen')) {
+            return;
+        }
+
+        $screen = get_current_screen();
+
+        if (!$screen || $screen->base !== 'dashboard') {
+            return;
+        }
+
+        if (wp_script_is('ap-dashboards-js', 'enqueued')) {
+            return;
+        }
+
+        self::enqueueAssets();
     }
 
     public static function registerDashboardWidgets(): void


### PR DESCRIPTION
## Summary
- enqueue dashboard assets when visiting the wp-admin dashboard so widgets function correctly
- reuse the existing dashboard asset logic while avoiding duplicate loads on other admin pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f097af48832e921b2a51a583f613