### PR TITLE
Add event submission widget to artist and organization dashboards

### DIFF
--- a/assets/css/ap-user-dashboard.css
+++ b/assets/css/ap-user-dashboard.css
@@ -119,3 +119,38 @@
 .ap-user-social-links a:hover {
   color: #005077;
 }
+
+.ap-dashboard-widget--event-submission {
+  display: block;
+}
+
+.ap-dashboard-event-widget__title {
+  margin-bottom: 0.5rem;
+}
+
+.ap-dashboard-event-widget__description {
+  margin: 0 0 1rem;
+  color: #444;
+}
+
+.ap-dashboard-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.ap-dashboard-button--primary {
+  background-color: #0073aa;
+  color: #fff;
+}
+
+.ap-dashboard-button--primary:hover,
+.ap-dashboard-button--primary:focus {
+  background-color: #005c87;
+  color: #fff;
+}

--- a/templates/dashboard/event-submission-widget.php
+++ b/templates/dashboard/event-submission-widget.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Dashboard event submission widget template.
+ *
+ * @var string $submission_url URL for submitting a new event.
+ */
+
+if (empty($submission_url)) {
+    echo '<p>' . esc_html__('Event submissions are currently unavailable.', 'artpulse') . '</p>';
+
+    return;
+}
+?>
+<div class="ap-dashboard-widget ap-dashboard-widget--event-submission">
+    <div class="ap-dashboard-widget__section ap-dashboard-widget__section--event-submission">
+        <h3 class="ap-dashboard-event-widget__title"><?php esc_html_e('Share a New Event', 'artpulse'); ?></h3>
+        <p class="ap-dashboard-event-widget__description">
+            <?php esc_html_e('Bring the community together by sharing details about your upcoming event.', 'artpulse'); ?>
+        </p>
+        <a class="ap-dashboard-button ap-dashboard-button--primary" href="<?php echo esc_url($submission_url); ?>">
+            <?php esc_html_e('Submit Event', 'artpulse'); ?>
+        </a>
+    </div>
+</div>

--- a/tests/Core/RoleDashboardsTest.php
+++ b/tests/Core/RoleDashboardsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Core;
+
+use ArtPulse\Core\RoleDashboards;
+use ArtPulse\Core\RoleSetup;
+
+class RoleDashboardsTest extends \WP_UnitTestCase
+{
+    public function set_up(): void
+    {
+        parent::set_up();
+        RoleSetup::install();
+        RoleDashboards::register();
+    }
+
+    public function tear_down(): void
+    {
+        remove_all_filters('artpulse_event_submission_url');
+        parent::tear_down();
+    }
+
+    public function test_event_submission_widget_is_registered_for_artist_dashboard(): void
+    {
+        global $wp_meta_boxes;
+
+        $submission_url = 'https://example.test/events/new';
+        add_filter('artpulse_event_submission_url', static fn () => $submission_url);
+
+        $artist_id = $this->factory->user->create([
+            'role'       => 'artist',
+            'user_login' => 'artist_user',
+        ]);
+
+        wp_set_current_user($artist_id);
+
+        $wp_meta_boxes = [];
+        do_action('wp_dashboard_setup');
+
+        $this->assertArrayHasKey('dashboard', $wp_meta_boxes);
+        $this->assertArrayHasKey('normal', $wp_meta_boxes['dashboard']);
+        $this->assertArrayHasKey('core', $wp_meta_boxes['dashboard']['normal']);
+        $this->assertArrayHasKey('artpulse_event_submission', $wp_meta_boxes['dashboard']['normal']['core']);
+        $widget = $wp_meta_boxes['dashboard']['normal']['core']['artpulse_event_submission'];
+        $this->assertIsArray($widget);
+        $this->assertSame([RoleDashboards::class, 'renderEventSubmissionWidget'], $widget['callback']);
+
+        $filtered_url = apply_filters('artpulse_event_submission_url', '');
+        $this->assertSame($submission_url, $filtered_url);
+    }
+}


### PR DESCRIPTION
## Summary
- register a dedicated dashboard widget that links to event submissions when artist or organization dashboards are available
- add a reusable template and dashboard-aligned styles for the submission widget
- cover the new widget registration with a WordPress unit test

## Testing
- composer test *(fails: vendor/bin/phpunit not found without installing dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f88f5f38832eaf0a713deb254fa1