### PR TITLE
Hook follow REST controller into rest_api_init

### DIFF
--- a/src/Community/FollowRestController.php
+++ b/src/Community/FollowRestController.php
@@ -10,6 +10,10 @@ class FollowRestController
 {
     public static function register(): void
     {
+        if ( ! ( did_action( 'rest_api_init' ) || doing_action( 'rest_api_init' ) ) ) {
+            return;
+        }
+
         register_rest_route('artpulse/v1', '/follows', [
             'methods'             => 'GET',
             'callback'            => [self::class, 'get_follows'],

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -44,6 +44,7 @@ class Plugin
 
         // REST API endpoints
         add_action( 'rest_api_init', [ \ArtPulse\Community\FavoritesRestController::class, 'register' ] );
+        add_action( 'rest_api_init', [ \ArtPulse\Community\FollowRestController::class, 'register' ] );
         add_action( 'rest_api_init', [ \ArtPulse\Community\NotificationRestController::class, 'register' ] );
         add_action( 'rest_api_init', [ \ArtPulse\Rest\SubmissionRestController::class, 'register' ] );
     }
@@ -115,7 +116,6 @@ class Plugin
         \ArtPulse\Core\NotificationShortcode::register();
         \ArtPulse\Admin\AdminListSorting::register();
         \ArtPulse\Rest\RestSortingSupport::register();
-        \ArtPulse\Community\FollowRestController::register();
         \ArtPulse\Admin\AdminListColumns::register();
         \ArtPulse\Admin\EnqueueAssets::register();
         \ArtPulse\Frontend\Shortcodes::register();


### PR DESCRIPTION
## Summary
- hook the follow REST controller into the rest_api_init bootstrap alongside other endpoints
- guard the controller so routes are registered only when the REST API init action is running
- stop registering the follow controller during the general core module bootstrap to avoid early REST calls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10226dbe4832e9f05ff7d60be0a85