### PR TITLE
Add artists directory shortcode with assets and tests

### DIFF
--- a/assets/css/ap-artists-directory.css
+++ b/assets/css/ap-artists-directory.css
@@ -1,0 +1,141 @@
+.ap-artists-directory {
+    display: block;
+    gap: 1.5rem;
+}
+
+.ap-directory-filter {
+    margin-bottom: 1.5rem;
+}
+
+.ap-directory-filter__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ap-directory-filter__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.5rem;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--ap-directory-border, #d0d7de);
+    border-radius: 999px;
+    background: var(--ap-directory-background, #ffffff);
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.ap-directory-filter__control:hover,
+.ap-directory-filter__control:focus-visible {
+    background: var(--ap-directory-accent, #3c50ff);
+    border-color: var(--ap-directory-accent, #3c50ff);
+    color: #ffffff;
+    outline: none;
+}
+
+.ap-directory-filter__control.is-active,
+.ap-directory-filter__control[aria-pressed="true"] {
+    background: var(--ap-directory-accent, #3c50ff);
+    border-color: var(--ap-directory-accent, #3c50ff);
+    color: #ffffff;
+}
+
+.ap-directory-results[aria-busy="true"] {
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+}
+
+.ap-directory-section {
+    margin-bottom: 2.5rem;
+}
+
+.ap-directory-heading {
+    font-size: 1.5rem;
+    margin: 0 0 1rem;
+}
+
+.ap-directory-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.ap-artist-card {
+    background: var(--ap-card-background, #ffffff);
+    border-radius: 0.75rem;
+    border: 1px solid var(--ap-card-border, #e5e7eb);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ap-artist-card:hover,
+.ap-artist-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.12);
+}
+
+.ap-artist-card__thumb img {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+}
+
+.ap-artist-card__body {
+    padding: 1rem 1.25rem 1.25rem;
+}
+
+.ap-artist-card__title {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+}
+
+.ap-artist-card__title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.ap-artist-card__title a:focus-visible,
+.ap-artist-card__title a:hover {
+    text-decoration: underline;
+}
+
+.ap-artist-card__meta {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.25rem;
+    font-size: 0.9rem;
+    color: var(--ap-card-muted, #4b5563);
+}
+
+.ap-directory-empty {
+    margin: 1rem 0 0;
+    font-style: italic;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+@media (max-width: 600px) {
+    .ap-directory-filter__control {
+        min-width: 2rem;
+        padding-inline: 0.6rem;
+    }
+
+    .ap-directory-grid {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+    }
+}

--- a/assets/js/ap-artists-directory.js
+++ b/assets/js/ap-artists-directory.js
@@ -1,0 +1,119 @@
+(function () {
+    'use strict';
+
+    function initDirectory(container) {
+        const filterControls = Array.from(container.querySelectorAll('.ap-directory-filter__control'));
+        const results = container.querySelector('.ap-directory-results');
+        if (!results || filterControls.length === 0) {
+            return;
+        }
+
+        const sections = Array.from(results.querySelectorAll('.ap-directory-section'));
+        const emptyState = results.querySelector('.ap-directory-empty');
+        let activeLetter = container.getAttribute('data-active-letter') || 'All';
+
+        function updateHistory(letter) {
+            if (!window.history || !window.history.replaceState) {
+                return;
+            }
+
+            const url = new URL(window.location.href);
+            if (letter === 'All') {
+                url.searchParams.delete('letter');
+            } else {
+                url.searchParams.set('letter', letter);
+            }
+
+            window.history.replaceState({}, document.title, url.toString());
+        }
+
+        function hasCards(section) {
+            return section ? section.querySelector('.ap-artist-card') !== null : false;
+        }
+
+        function toggleSections(letter) {
+            results.setAttribute('aria-busy', 'true');
+
+            let hasVisibleCards = false;
+            let targetSection = null;
+
+            sections.forEach((section) => {
+                const sectionLetter = section.getAttribute('data-letter');
+                const shouldShow = letter === 'All' || sectionLetter === letter;
+
+                if (shouldShow) {
+                    section.removeAttribute('hidden');
+                    if (!targetSection && sectionLetter === letter) {
+                        targetSection = section;
+                    }
+                    hasVisibleCards = hasVisibleCards || hasCards(section);
+                } else {
+                    section.setAttribute('hidden', '');
+                }
+            });
+
+            if (letter !== 'All' && !targetSection) {
+                hasVisibleCards = false;
+            }
+
+            if (emptyState) {
+                if (hasVisibleCards) {
+                    emptyState.setAttribute('hidden', '');
+                } else {
+                    emptyState.removeAttribute('hidden');
+                }
+            }
+
+            requestAnimationFrame(() => {
+                results.setAttribute('aria-busy', 'false');
+            });
+        }
+
+        function setLetter(letter, { updateUrl = true, force = false } = {}) {
+            if (!force && letter === activeLetter) {
+                return;
+            }
+
+            activeLetter = letter;
+            container.setAttribute('data-active-letter', letter);
+
+            filterControls.forEach((control) => {
+                const controlLetter = control.getAttribute('data-letter');
+                const isActive = controlLetter === letter;
+                control.classList.toggle('is-active', isActive);
+                control.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+
+            toggleSections(letter);
+
+            if (updateUrl) {
+                updateHistory(letter);
+            }
+        }
+
+        filterControls.forEach((control) => {
+            control.addEventListener('click', (event) => {
+                event.preventDefault();
+                const letter = control.getAttribute('data-letter') || 'All';
+                setLetter(letter);
+            });
+        });
+
+        setLetter(activeLetter, { updateUrl: false, force: true });
+    }
+
+    function ready(fn) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', fn);
+        } else {
+            fn();
+        }
+    }
+
+    ready(function () {
+        const directories = document.querySelectorAll('.ap-artists-directory');
+        directories.forEach((directory) => {
+            initDirectory(directory);
+        });
+    });
+})();

--- a/documentation/README
+++ b/documentation/README
@@ -1,0 +1,45 @@
+# Artists Directory Shortcode
+
+Use the `[ap_artists_directory]` shortcode to output a responsive, accessible listing of published `artpulse_artist` profiles. The directory automatically groups artists alphabetically, presents an A–Z filter bar, and exposes each section through an `aria-live="polite"` results container so screen readers announce updates when visitors change letters.
+
+## Basic Usage
+
+Add the shortcode to any page or post:
+
+```
+[ap_artists_directory]
+```
+
+When the page loads, visitors see an alphabet filter bar and an "All" view that includes every published artist. Clicking or tapping on a letter filters the results client-side, while query parameters such as `?letter=B` keep the experience functional for visitors without JavaScript or for deep-linking to a specific letter.
+
+## Optional Attributes
+
+The shortcode accepts the following optional attributes:
+
+- `orderby` – Field to order by (defaults to `title`).
+- `order` – Sort direction (`ASC` or `DESC`, defaults to `ASC`).
+- `posts_per_page` – Number of artists to retrieve (defaults to `-1` to show all artists).
+- `letter` – Set the default active letter (for example `letter="C"`).
+
+Example:
+
+```
+[ap_artists_directory orderby="title" order="ASC" posts_per_page="200" letter="B"]
+```
+
+## Customising Output
+
+Developers can tailor the directory using these WordPress filters:
+
+- `artpulse_artists_directory_args` – Modify the underlying `WP_Query` arguments before artists are fetched.
+- `artpulse_artists_directory_fields` – Adjust the data displayed for each card (e.g., add organisation details, role, or location metadata).
+
+The shortcode caches rendered artist data for 12 hours to keep the directory fast. Caches are automatically cleared whenever `artpulse_artist` posts are saved, trashed, or deleted.
+
+## Front-End Behaviour
+
+- The filter bar uses focusable controls with `aria-pressed` states for accessibility.
+- The results grid (`.ap-directory-grid`) adapts to various screen sizes.
+- Sections without matching artists are hidden with the `hidden` attribute, and a built-in empty state message appears when a letter has no results.
+
+No additional configuration is required—enqueueing of the associated CSS (`assets/css/ap-artists-directory.css`) and JavaScript (`assets/js/ap-artists-directory.js`) happens automatically when the shortcode is present on a singular page.

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -128,6 +128,7 @@ class Plugin
         \ArtPulse\Frontend\OrganizationEventForm::register();
         \ArtPulse\Frontend\UserProfileShortcode::register();
         \ArtPulse\Frontend\ProfileEditShortcode::register();
+        \ArtPulse\Frontend\ArtistsDirectory::register();
         \ArtPulse\Frontend\PortfolioBuilder::register();
         \ArtPulse\Frontend\TemplateLoader::register();
         \ArtPulse\Admin\MetaBoxesRelationship::register();

--- a/src/Frontend/ArtistsDirectory.php
+++ b/src/Frontend/ArtistsDirectory.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace ArtPulse\Frontend;
+
+class ArtistsDirectory
+{
+    private const SHORTCODE = 'ap_artists_directory';
+    private const STYLE_HANDLE = 'ap-artists-directory';
+    private const SCRIPT_HANDLE = 'ap-artists-directory';
+    private const TRANSIENT_PREFIX = 'ap_artists_directory_';
+    private const CACHE_KEYS_OPTION = 'ap_artists_directory_cache_keys';
+
+    public static function register(): void
+    {
+        add_shortcode(self::SHORTCODE, [self::class, 'render_shortcode']);
+        add_action('init', [self::class, 'register_assets']);
+        add_action('wp_enqueue_scripts', [self::class, 'maybe_enqueue_assets']);
+
+        add_action('save_post_artpulse_artist', [self::class, 'clear_cache'], 10, 0);
+        add_action('trashed_post', [self::class, 'maybe_clear_cache']);
+        add_action('deleted_post', [self::class, 'maybe_clear_cache']);
+    }
+
+    public static function register_assets(): void
+    {
+        $plugin_url = plugins_url('/', ARTPULSE_PLUGIN_FILE);
+
+        wp_register_style(
+            self::STYLE_HANDLE,
+            $plugin_url . 'assets/css/ap-artists-directory.css',
+            [],
+            ARTPULSE_VERSION
+        );
+
+        wp_register_script(
+            self::SCRIPT_HANDLE,
+            $plugin_url . 'assets/js/ap-artists-directory.js',
+            [],
+            ARTPULSE_VERSION,
+            true
+        );
+    }
+
+    public static function maybe_enqueue_assets(): void
+    {
+        if (!is_singular()) {
+            return;
+        }
+
+        $post_id = get_queried_object_id();
+        if ($post_id && self::post_has_shortcode($post_id)) {
+            wp_enqueue_style(self::STYLE_HANDLE);
+            wp_enqueue_script(self::SCRIPT_HANDLE);
+        }
+    }
+
+    public static function render_shortcode(array $atts = []): string
+    {
+        self::ensure_assets_enqueued();
+
+        $atts = shortcode_atts(
+            [
+                'orderby' => 'title',
+                'order' => 'ASC',
+                'posts_per_page' => -1,
+                'letter' => '',
+            ],
+            $atts,
+            self::SHORTCODE
+        );
+
+        $requested_letter = strtoupper($atts['letter'] ?: sanitize_text_field(wp_unslash($_GET['letter'] ?? '')));
+        $active_letter = $requested_letter ?: 'All';
+
+        $query_args = [
+            'post_type' => 'artpulse_artist',
+            'post_status' => 'publish',
+            'orderby' => sanitize_key($atts['orderby']),
+            'order' => strtoupper($atts['order']) === 'DESC' ? 'DESC' : 'ASC',
+            'posts_per_page' => (int) $atts['posts_per_page'],
+            'fields' => 'ids',
+        ];
+
+        $query_args = apply_filters('artpulse_artists_directory_args', $query_args, $atts);
+
+        $cache_key = self::get_cache_key($query_args);
+        $artists = get_transient($cache_key);
+
+        if (false === $artists) {
+            $artist_posts = get_posts($query_args);
+            $artists = [];
+
+            foreach ($artist_posts as $post_id) {
+                $post = get_post($post_id);
+                if (!$post instanceof \WP_Post) {
+                    continue;
+                }
+
+                $organization = get_post_meta($post->ID, '_ap_artist_org', true);
+                $role = get_post_meta($post->ID, '_ap_artist_role', true);
+                $location = get_post_meta($post->ID, '_ap_artist_location', true);
+
+                $fields = [
+                    'thumbnail' => get_the_post_thumbnail($post->ID, 'medium'),
+                    'name' => sprintf(
+                        '<a href="%s">%s</a>',
+                        esc_url(get_permalink($post)),
+                        esc_html(get_the_title($post))
+                    ),
+                    'organization' => is_scalar($organization) ? sanitize_text_field((string) $organization) : $organization,
+                    'role' => is_scalar($role) ? sanitize_text_field((string) $role) : $role,
+                    'location' => is_scalar($location) ? sanitize_text_field((string) $location) : $location,
+                ];
+
+                $fields = apply_filters('artpulse_artists_directory_fields', $fields, $post);
+
+                $artists[] = [
+                    'id' => $post->ID,
+                    'title' => get_the_title($post),
+                    'fields' => $fields,
+                ];
+            }
+
+            set_transient($cache_key, $artists, 12 * HOUR_IN_SECONDS);
+            self::remember_cache_key($cache_key);
+        }
+
+        if (empty($artists)) {
+            return '<p class="ap-artists-directory-empty">' . esc_html__('No artists found at this time.', 'artpulse') . '</p>';
+        }
+
+        $groups = self::group_artists_by_letter($artists);
+        $letters = array_merge(['All'], range('A', 'Z'), ['#']);
+        $active_letter = in_array($active_letter, $letters, true) ? $active_letter : 'All';
+
+        $has_results_for_active = 'All' === $active_letter
+            ? !empty($artists)
+            : !empty($groups[$active_letter] ?? []);
+
+        ob_start();
+        ?>
+        <div class="ap-artists-directory" data-active-letter="<?php echo esc_attr($active_letter); ?>" data-default-letter="<?php echo esc_attr($active_letter); ?>">
+            <nav class="ap-directory-filter" aria-label="<?php esc_attr_e('Filter artists alphabetically', 'artpulse'); ?>">
+                <ul class="ap-directory-filter__list">
+                    <?php foreach ($letters as $letter) :
+                        if ('#' === $letter && empty($groups['#'] ?? [])) {
+                            continue;
+                        }
+                        $is_active = $letter === $active_letter;
+                        $url = 'All' === $letter
+                            ? esc_url(remove_query_arg('letter'))
+                            : esc_url(add_query_arg('letter', $letter));
+                        ?>
+                        <li class="ap-directory-filter__item">
+                            <a
+                                href="<?php echo $url; ?>"
+                                class="ap-directory-filter__control<?php echo $is_active ? ' is-active' : ''; ?>"
+                                role="button"
+                                data-letter="<?php echo esc_attr($letter); ?>"
+                                aria-pressed="<?php echo $is_active ? 'true' : 'false'; ?>"
+                            >
+                                <?php echo 'All' === $letter ? esc_html__('All', 'artpulse') : esc_html($letter); ?>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </nav>
+            <div class="ap-directory-results" aria-live="polite" aria-busy="false">
+                <?php foreach ($groups as $letter => $items) :
+                    $is_visible = 'All' === $active_letter || $letter === $active_letter;
+                    $hidden_attr = $is_visible ? '' : ' hidden';
+                    ?>
+                    <section class="ap-directory-section" data-letter="<?php echo esc_attr($letter); ?>"<?php echo $hidden_attr; ?>>
+                        <h2 class="ap-directory-heading">
+                            <?php echo 'All' === $letter ? esc_html__('All Artists', 'artpulse') : esc_html($letter); ?>
+                        </h2>
+                        <div class="ap-directory-grid">
+                            <?php foreach ($items as $artist) :
+                                $fields = $artist['fields'];
+                                ?>
+                                <article class="ap-artist-card">
+                                    <?php if (!empty($fields['thumbnail'])) : ?>
+                                        <div class="ap-artist-card__thumb">
+                                            <?php echo wp_kses_post($fields['thumbnail']); ?>
+                                        </div>
+                                    <?php endif; ?>
+                                    <div class="ap-artist-card__body">
+                                        <h3 class="ap-artist-card__title">
+                                            <?php echo isset($fields['name']) ? wp_kses_post($fields['name']) : esc_html($artist['title']); ?>
+                                        </h3>
+                                        <?php if (!empty($fields['organization']) || !empty($fields['role']) || !empty($fields['location'])) : ?>
+                                            <ul class="ap-artist-card__meta">
+                                                <?php if (!empty($fields['organization'])) : ?>
+                                                    <li class="ap-artist-card__meta-item ap-artist-card__meta-item--organization">
+                                                        <?php echo wp_kses_post(is_array($fields['organization']) ? implode(' ', $fields['organization']) : $fields['organization']); ?>
+                                                    </li>
+                                                <?php endif; ?>
+                                                <?php if (!empty($fields['role'])) : ?>
+                                                    <li class="ap-artist-card__meta-item ap-artist-card__meta-item--role">
+                                                        <?php echo wp_kses_post(is_array($fields['role']) ? implode(' ', $fields['role']) : $fields['role']); ?>
+                                                    </li>
+                                                <?php endif; ?>
+                                                <?php if (!empty($fields['location'])) : ?>
+                                                    <li class="ap-artist-card__meta-item ap-artist-card__meta-item--location">
+                                                        <?php echo wp_kses_post(is_array($fields['location']) ? implode(' ', $fields['location']) : $fields['location']); ?>
+                                                    </li>
+                                                <?php endif; ?>
+                                            </ul>
+                                        <?php endif; ?>
+                                    </div>
+                                </article>
+                            <?php endforeach; ?>
+                        </div>
+                    </section>
+                <?php endforeach; ?>
+                <p class="ap-directory-empty"<?php echo $has_results_for_active ? ' hidden' : ''; ?>><?php esc_html_e('No artists match the selected letter.', 'artpulse'); ?></p>
+            </div>
+        </div>
+        <?php
+        return trim((string) ob_get_clean());
+    }
+
+    public static function clear_cache(?int $post_id = null): void
+    {
+        $keys = get_option(self::CACHE_KEYS_OPTION, []);
+        if (!is_array($keys)) {
+            $keys = [];
+        }
+
+        foreach ($keys as $key) {
+            delete_transient($key);
+        }
+
+        update_option(self::CACHE_KEYS_OPTION, []);
+    }
+
+    public static function maybe_clear_cache(int $post_id): void
+    {
+        if ('artpulse_artist' === get_post_type($post_id)) {
+            self::clear_cache();
+        }
+    }
+
+    private static function ensure_assets_enqueued(): void
+    {
+        if (!wp_style_is(self::STYLE_HANDLE, 'enqueued')) {
+            wp_enqueue_style(self::STYLE_HANDLE);
+        }
+        if (!wp_script_is(self::SCRIPT_HANDLE, 'enqueued')) {
+            wp_enqueue_script(self::SCRIPT_HANDLE);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $query_args
+     */
+    private static function get_cache_key(array $query_args): string
+    {
+        return self::TRANSIENT_PREFIX . md5(wp_json_encode($query_args));
+    }
+
+    private static function remember_cache_key(string $cache_key): void
+    {
+        $keys = get_option(self::CACHE_KEYS_OPTION, []);
+        if (!is_array($keys)) {
+            $keys = [];
+        }
+
+        if (!in_array($cache_key, $keys, true)) {
+            $keys[] = $cache_key;
+            update_option(self::CACHE_KEYS_OPTION, $keys);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $artists
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private static function group_artists_by_letter(array $artists): array
+    {
+        $groups = ['All' => []];
+
+        foreach ($artists as $artist) {
+            $title = $artist['title'];
+            $first_character = function_exists('mb_substr')
+                ? mb_substr($title, 0, 1)
+                : substr($title, 0, 1);
+            $first_letter = strtoupper((string) $first_character);
+            if (!preg_match('/[A-Z]/', $first_letter)) {
+                $first_letter = '#';
+            }
+
+            if (!isset($groups[$first_letter])) {
+                $groups[$first_letter] = [];
+            }
+
+            $groups['All'][] = $artist;
+            $groups[$first_letter][] = $artist;
+        }
+
+        ksort($groups);
+        if (isset($groups['All'])) {
+            $all = $groups['All'];
+            unset($groups['All']);
+            $groups = array_merge(['All' => $all], $groups);
+        }
+
+        return $groups;
+    }
+
+    private static function post_has_shortcode(int $post_id): bool
+    {
+        $post = get_post($post_id);
+        if (!$post instanceof \WP_Post) {
+            return false;
+        }
+
+        if (has_shortcode($post->post_content, self::SHORTCODE)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Frontend/ArtistsDirectoryTest.php
+++ b/tests/Frontend/ArtistsDirectoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use ArtPulse\Frontend\ArtistsDirectory;
+
+class ArtistsDirectoryTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ArtistsDirectory::register();
+        ArtistsDirectory::clear_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        ArtistsDirectory::clear_cache();
+        parent::tearDown();
+    }
+
+    public function testShortcodeGroupsArtistsByLetter(): void
+    {
+        self::factory()->post->create([
+            'post_type' => 'artpulse_artist',
+            'post_title' => 'Alice Aardvark',
+            'post_status' => 'publish',
+        ]);
+        self::factory()->post->create([
+            'post_type' => 'artpulse_artist',
+            'post_title' => 'Bruno Brass',
+            'post_status' => 'publish',
+        ]);
+        self::factory()->post->create([
+            'post_type' => 'artpulse_artist',
+            'post_title' => '3D Collective',
+            'post_status' => 'publish',
+        ]);
+
+        $output = do_shortcode('[ap_artists_directory]');
+
+        $this->assertStringContainsString('ap-directory-filter', $output, 'Expected alphabet filter navigation to be present.');
+        $this->assertMatchesRegularExpression('/<section[^>]+data-letter="All"[^>]*>.*Alice Aardvark.*Bruno Brass/s', $output);
+        $this->assertMatchesRegularExpression('/<section[^>]+data-letter="A"[^>]*>.*Alice Aardvark/s', $output);
+        $this->assertMatchesRegularExpression('/<section[^>]+data-letter="B"[^>]*>.*Bruno Brass/s', $output);
+        $this->assertMatchesRegularExpression('/<section[^>]+data-letter="#"[^>]*>.*3D Collective/s', $output);
+        $this->assertDoesNotMatchRegularExpression('/<section[^>]+data-letter="B"[^>]*>.*Alice Aardvark/s', $output, 'Letter sections should only include matching artists.');
+    }
+}

--- a/tests/e2e/artists-directory.spec.js
+++ b/tests/e2e/artists-directory.spec.js
@@ -1,0 +1,110 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+
+async function runWpCli(args, { ignoreError = false } = {}) {
+  try {
+    const { stdout } = await execFileAsync('npx', ['wp-env', 'run', 'tests-cli', ...args], {
+      env: process.env,
+    });
+    return stdout.trim();
+  } catch (error) {
+    if (ignoreError) {
+      const stdout = error.stdout ? error.stdout.toString() : '';
+      return stdout.trim();
+    }
+    throw error;
+  }
+}
+
+describe('Artists directory shortcode', () => {
+  const createdArtistIds = [];
+  let pageId = 0;
+
+  beforeAll(async () => {
+    const artistData = [
+      { title: 'Amelia Abstract' },
+      { title: 'Benedict Brush' },
+      { title: 'Camila Canvas' },
+    ];
+
+    for (const artist of artistData) {
+      const artistIdOutput = await runWpCli([
+        'wp',
+        'post',
+        'create',
+        '--post_type=artpulse_artist',
+        `--post_title=${artist.title}`,
+        '--post_status=publish',
+        '--porcelain',
+      ]);
+      const artistId = parseInt(artistIdOutput, 10);
+      expect(Number.isNaN(artistId)).toBe(false);
+      createdArtistIds.push(artistId);
+    }
+
+    const pageOutput = await runWpCli([
+      'wp',
+      'post',
+      'create',
+      '--post_type=page',
+      '--post_title=Artists Directory Test Page',
+      '--post_status=publish',
+      '--post_content=[ap_artists_directory]',
+      '--porcelain',
+    ]);
+    pageId = parseInt(pageOutput, 10);
+    expect(Number.isNaN(pageId)).toBe(false);
+  });
+
+  afterAll(async () => {
+    if (pageId) {
+      await runWpCli(['wp', 'post', 'delete', String(pageId), '--force'], { ignoreError: true });
+    }
+
+    for (const artistId of createdArtistIds) {
+      await runWpCli(['wp', 'post', 'delete', String(artistId), '--force'], { ignoreError: true });
+    }
+  });
+
+  it('filters artists by letter selection', async () => {
+    await page.goto(`${BASE_URL}/?p=${pageId}`);
+    await page.waitForSelector('.ap-directory-filter');
+    await page.waitForSelector('.ap-directory-section[data-letter="All"] .ap-artist-card');
+
+    const filterButton = await page.waitForSelector('.ap-directory-filter__control[data-letter="B"]');
+    await filterButton.click();
+
+    await page.waitForFunction(() => {
+      const activeControl = document.querySelector('.ap-directory-filter__control.is-active');
+      const bSection = document.querySelector('.ap-directory-section[data-letter="B"]');
+      const aSection = document.querySelector('.ap-directory-section[data-letter="A"]');
+      return (
+        activeControl &&
+        activeControl.getAttribute('data-letter') === 'B' &&
+        bSection &&
+        !bSection.hasAttribute('hidden') &&
+        (!aSection || aSection.hasAttribute('hidden'))
+      );
+    });
+
+    const visibleTitles = await page.$$eval(
+      '.ap-directory-section:not([hidden]) .ap-artist-card__title',
+      (nodes) => nodes.map((node) => node.textContent.trim())
+    );
+
+    expect(visibleTitles).toEqual(['Benedict Brush']);
+
+    const hiddenTitles = await page.$$eval(
+      '.ap-directory-section[hidden] .ap-artist-card__title',
+      (nodes) => nodes.map((node) => node.textContent.trim())
+    );
+
+    expect(hiddenTitles).toEqual(expect.arrayContaining(['Amelia Abstract', 'Camila Canvas']));
+
+    const emptyStateHidden = await page.$eval('.ap-directory-empty', (el) => el.hasAttribute('hidden'));
+    expect(emptyStateHidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an ArtistsDirectory frontend module that registers the shortcode, assets, caching, and cache invalidation hooks
- build the shortcode renderer with accessible markup, alphabetic grouping, filters, and companion CSS/JS assets
- document usage and cover functionality with PHPUnit and Playwright end-to-end tests

## Testing
- composer test *(fails: vendor/bin/phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15f5519d0832e93b4eba0675dbb1b