### PR TITLE
Add organizations directory shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ ArtPulse Management is a powerful WordPress plugin that enables seamless managem
 
 🧭 Organization Onboarding — `[ap_register_organization]` shortcode to collect org sign-ups, auto-assign creators, notify admins, and promote follow/favorite actions
 
+📇 Organization Directory — `[ap_orgs_directory]` shortcode renders an A–Z directory with search, favorites, and taxonomy filters
+
 🧑‍💻 Installation
 Clone or download this repo into your WordPress plugins directory:
 
@@ -69,6 +71,14 @@ Optional tools:
 phpunit for unit tests
 
 phpcs for coding standards (composer run lint)
+
+📘 Shortcode Examples
+
+```
+[ap_orgs_directory]
+[ap_orgs_directory taxonomy="sector:music" per_page="12"]
+[ap_orgs_directory show_search="false" letters="A,B,C,All"]
+```
 
 🔌 Plugin Structure
 Folder	Purpose

--- a/assets/css/ap-orgs-directory.css
+++ b/assets/css/ap-orgs-directory.css
@@ -1,0 +1,185 @@
+.ap-orgs-dir {
+  display: block;
+  margin: 2rem 0;
+  color: var(--ap-text, inherit);
+}
+
+.ap-orgs-dir .ap-orgs-dir__summary {
+  margin: 1rem 0;
+  font-weight: 600;
+}
+
+.ap-az {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+
+.ap-az__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--ap-border, #ccc);
+  background: var(--ap-surface, #fff);
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.ap-az__link:is(:hover, :focus-visible) {
+  border-color: var(--ap-accent, #222);
+  color: var(--ap-accent, #222);
+  outline: none;
+}
+
+.ap-az__link.is-active {
+  background: var(--ap-accent, #222);
+  border-color: var(--ap-accent, #222);
+  color: #fff;
+}
+
+.ap-orgs-dir__search {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.ap-orgs-dir__search input[type="search"] {
+  flex: 1 1 240px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ap-border, #ccc);
+  border-radius: 0.4rem;
+}
+
+.ap-orgs-dir__submit {
+  padding: 0.5rem 1rem;
+  border-radius: 0.4rem;
+  border: none;
+  background: var(--ap-accent, #222);
+  color: #fff;
+  cursor: pointer;
+}
+
+.ap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.ap-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ap-border, #e0e0e0);
+  border-radius: 0.75rem;
+  background: var(--ap-card, #fff);
+  overflow: hidden;
+  min-height: 100%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.ap-card__thumb img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.ap-card__body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ap-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.ap-card__title a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.ap-card__excerpt {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--ap-muted, #555);
+}
+
+.ap-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.ap-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--ap-badge-bg, #f1f1f1);
+  color: var(--ap-badge-text, #333);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ap-card__favorite {
+  margin-top: auto;
+  font-weight: 600;
+  color: var(--ap-accent, #222);
+}
+
+.ap-orgs-dir__empty[hidden] {
+  display: none !important;
+}
+
+.ap-orgs-dir__pagination {
+  margin-top: 2rem;
+}
+
+.ap-orgs-dir__pagination-list {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.ap-orgs-dir__page-link {
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--ap-border, #ccc);
+  text-decoration: none;
+  color: inherit;
+}
+
+.ap-orgs-dir__page-link.is-active {
+  background: var(--ap-accent, #222);
+  color: #fff;
+  border-color: var(--ap-accent, #222);
+}
+
+.ap-orgs-dir__page-link:is(:hover, :focus-visible) {
+  border-color: var(--ap-accent, #222);
+  outline: none;
+}
+
+@media (max-width: 600px) {
+  .ap-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+}

--- a/assets/js/ap-orgs-directory.js
+++ b/assets/js/ap-orgs-directory.js
@@ -1,0 +1,145 @@
+(function () {
+  const debounce = (fn, wait) => {
+    let timeout;
+    return (...args) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(null, args), wait);
+    };
+  };
+
+  const updateUrl = (letter, search) => {
+    const url = new URL(window.location.href);
+    if (letter && letter !== 'All') {
+      url.searchParams.set('letter', letter);
+    } else {
+      url.searchParams.delete('letter');
+    }
+
+    if (search) {
+      url.searchParams.set('search', search);
+    } else {
+      url.searchParams.delete('search');
+    }
+
+    url.searchParams.delete('page');
+    window.history.replaceState({}, '', url.toString());
+  };
+
+  const render = (wrapper, data, letter, search) => {
+    const grid = wrapper.querySelector('.ap-grid');
+    const emptyState = wrapper.querySelector('.ap-orgs-dir__empty');
+    const summary = wrapper.querySelector('.ap-orgs-dir__summary');
+
+    if (!grid) {
+      return;
+    }
+
+    const activeLetter = letter || 'All';
+    const searchValue = search ? search.toLowerCase() : '';
+
+    const matches = data.items.filter((item) => {
+      const matchesLetter = activeLetter === 'All' || item.letter === activeLetter;
+      const matchesSearch = !searchValue || item.search_index.indexOf(searchValue) !== -1;
+      return matchesLetter && matchesSearch;
+    });
+
+    grid.setAttribute('aria-busy', 'true');
+    grid.innerHTML = matches.map((item) => item.html).join('');
+    grid.setAttribute('aria-busy', 'false');
+
+    if (summary) {
+      const count = matches.length;
+      const text = count === 1 ? window.apOrgsDirectoryL10n.one.replace('%s', count) : window.apOrgsDirectoryL10n.many.replace('%s', count.toLocaleString());
+      summary.textContent = text;
+    }
+
+    if (emptyState) {
+      if (matches.length === 0) {
+        emptyState.hidden = false;
+      } else {
+        emptyState.hidden = true;
+      }
+    }
+
+    const pagination = wrapper.querySelector('.ap-orgs-dir__pagination');
+    if (pagination) {
+      pagination.remove();
+    }
+  };
+
+  const enhanceDirectory = (wrapper) => {
+    const dataNode = wrapper.querySelector('.ap-orgs-dir__data');
+    if (!dataNode) {
+      return;
+    }
+
+    let data;
+    try {
+      data = JSON.parse(dataNode.textContent || '{}');
+    } catch (e) {
+      return;
+    }
+
+    if (!data || !Array.isArray(data.items)) {
+      return;
+    }
+
+    const letters = wrapper.querySelectorAll('.ap-az__link');
+    const searchInput = wrapper.querySelector('#ap-orgs-dir-search');
+
+    const l10n = {
+      one: '%s organization found',
+      many: '%s organizations found',
+      ...(window.apOrgsDirectoryL10n || {}),
+    };
+
+    window.apOrgsDirectoryL10n = l10n;
+
+    const apply = (letter, search) => {
+      render(wrapper, data, letter, search);
+      updateUrl(letter, search);
+    };
+
+    let currentLetter = data.activeLetter || 'All';
+    let currentSearch = data.searchTerm || '';
+
+    const setActiveLetter = (letter) => {
+      currentLetter = letter;
+      letters.forEach((link) => {
+        const linkLetter = link.getAttribute('data-letter');
+        if (linkLetter === letter) {
+          link.classList.add('is-active');
+          link.setAttribute('aria-current', 'true');
+        } else {
+          link.classList.remove('is-active');
+          link.removeAttribute('aria-current');
+        }
+      });
+    };
+
+    setActiveLetter(currentLetter);
+    apply(currentLetter, currentSearch);
+
+    letters.forEach((link) => {
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        const letter = link.getAttribute('data-letter') || 'All';
+        setActiveLetter(letter);
+        apply(letter, currentSearch);
+      });
+    });
+
+    if (searchInput) {
+      searchInput.value = currentSearch;
+      const handleSearch = debounce(() => {
+        currentSearch = searchInput.value.trim();
+        apply(currentLetter, currentSearch);
+      }, 250);
+      searchInput.addEventListener('input', handleSearch);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.ap-orgs-dir').forEach((wrapper) => enhanceDirectory(wrapper));
+  });
+})();

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -129,6 +129,7 @@ class Plugin
         \ArtPulse\Frontend\UserProfileShortcode::register();
         \ArtPulse\Frontend\ProfileEditShortcode::register();
         \ArtPulse\Frontend\ArtistsDirectory::register();
+        \ArtPulse\Frontend\OrgsDirectory::register();
         \ArtPulse\Frontend\PortfolioBuilder::register();
         \ArtPulse\Frontend\TemplateLoader::register();
         \ArtPulse\Admin\MetaBoxesRelationship::register();

--- a/src/Frontend/OrgsDirectory.php
+++ b/src/Frontend/OrgsDirectory.php
@@ -1,0 +1,676 @@
+<?php
+
+namespace ArtPulse\Frontend;
+
+use ArtPulse\Community\FavoritesManager;
+use WP_Query;
+use WP_Post;
+
+class OrgsDirectory
+{
+    private const TRANSIENT_PREFIX = 'ap_orgs_dir_';
+    private const TRANSIENT_ALL_PREFIX = 'ap_orgs_dir_all_';
+
+    public static function register(): void
+    {
+        add_shortcode('ap_orgs_directory', [self::class, 'render_shortcode']);
+        add_action('init', [self::class, 'register_cache_busters']);
+        add_action('wp_enqueue_scripts', [self::class, 'register_assets']);
+    }
+
+    public static function register_assets(): void
+    {
+        if (!wp_style_is('ap-orgs-directory', 'registered')) {
+            wp_register_style(
+                'ap-orgs-directory',
+                plugins_url('assets/css/ap-orgs-directory.css', ARTPULSE_PLUGIN_FILE),
+                [],
+                defined('ARTPULSE_VERSION') ? ARTPULSE_VERSION : null
+            );
+        }
+
+        if (!wp_script_is('ap-orgs-directory', 'registered')) {
+            wp_register_script(
+                'ap-orgs-directory',
+                plugins_url('assets/js/ap-orgs-directory.js', ARTPULSE_PLUGIN_FILE),
+                [],
+                defined('ARTPULSE_VERSION') ? ARTPULSE_VERSION : null,
+                true
+            );
+        }
+    }
+
+    public static function register_cache_busters(): void
+    {
+        $post_type = self::get_post_type_slug();
+
+        add_action('save_post_' . $post_type, [self::class, 'flush_cache']);
+        add_action('deleted_post', [self::class, 'maybe_flush_on_delete']);
+    }
+
+    public static function flush_cache(): void
+    {
+        global $wpdb;
+
+        $like_patterns = [
+            '_transient_' . self::TRANSIENT_PREFIX . '%',
+            '_transient_timeout_' . self::TRANSIENT_PREFIX . '%',
+            '_transient_' . self::TRANSIENT_ALL_PREFIX . '%',
+            '_transient_timeout_' . self::TRANSIENT_ALL_PREFIX . '%',
+        ];
+
+        foreach ($like_patterns as $pattern) {
+            $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                    $pattern
+                )
+            );
+        }
+    }
+
+    public static function maybe_flush_on_delete(int $post_id): void
+    {
+        $post = get_post($post_id);
+        if ($post instanceof WP_Post && $post->post_type === self::get_post_type_slug()) {
+            self::flush_cache();
+        }
+    }
+
+    public static function render_shortcode($atts = []): string
+    {
+        if (!post_type_exists(self::get_post_type_slug())) {
+            return '';
+        }
+
+        $atts = shortcode_atts([
+            'letters'        => 'A-Z|All',
+            'per_page'       => 24,
+            'taxonomy'       => '',
+            'show_search'    => 'true',
+            'show_favorites' => 'true',
+        ], $atts, 'ap_orgs_directory');
+
+        $letters = apply_filters('artpulse_orgs_directory_letters', self::parse_letters($atts['letters']));
+
+        $per_page = (int) $atts['per_page'];
+        if ($per_page <= 0) {
+            $per_page = 24;
+        }
+
+        $taxonomy_filter = self::parse_taxonomy_attribute($atts['taxonomy']);
+
+        $show_search = self::is_truthy($atts['show_search']);
+        $show_favorites = self::is_truthy($atts['show_favorites']);
+
+        $active_letter = isset($_GET['letter']) ? sanitize_text_field(wp_unslash($_GET['letter'])) : '';
+        $active_letter = self::normalize_letter_query($active_letter, $letters);
+
+        $search_term = isset($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : '';
+
+        $page = isset($_GET['page']) ? max(1, (int) $_GET['page']) : 1;
+
+        $post_type = self::get_post_type_slug();
+
+        $all_items = self::get_all_items($post_type, $taxonomy_filter, $search_term);
+
+        $pagination = self::get_paginated_ids(
+            $all_items,
+            $active_letter,
+            $per_page,
+            $page,
+            $taxonomy_filter,
+            $search_term
+        );
+
+        $favorites_lookup = [];
+        if ($show_favorites && function_exists('is_user_logged_in') && is_user_logged_in() && class_exists(FavoritesManager::class)) {
+            $user_favorites = FavoritesManager::get_user_favorites(get_current_user_id(), $post_type);
+            foreach ($user_favorites as $favorite) {
+                if ((int) $favorite->object_id > 0) {
+                    $favorites_lookup[(int) $favorite->object_id] = true;
+                }
+            }
+        }
+
+        $cards_by_id = [];
+        foreach ($all_items as $item) {
+            $item_id = (int) $item['id'];
+            $item['is_favorited'] = isset($favorites_lookup[$item_id]);
+            $cards_by_id[$item_id] = self::prepare_card_markup($item);
+        }
+
+        $visible_ids = $pagination['ids'];
+        $visible_markup = array_map(
+            static function ($id) use ($cards_by_id) {
+                return $cards_by_id[$id] ?? '';
+            },
+            $visible_ids
+        );
+
+        wp_enqueue_style('ap-orgs-directory');
+        wp_localize_script(
+            'ap-orgs-directory',
+            'apOrgsDirectoryL10n',
+            [
+                'one'  => esc_html__('%s organization found', 'artpulse'),
+                'many' => esc_html__('%s organizations found', 'artpulse'),
+            ]
+        );
+        wp_enqueue_script('ap-orgs-directory');
+
+        $current_url = self::get_current_url();
+        $base_url = remove_query_arg(['letter', 'page'], $current_url);
+
+        $total_results = (int) $pagination['total'];
+        $total_pages = (int) $pagination['total_pages'];
+
+        $json_data = [
+            'items'      => array_values(array_map(
+                static function ($item) use ($favorites_lookup) {
+                    $item_id = (int) $item['id'];
+                    $item['is_favorited'] = isset($favorites_lookup[$item_id]);
+                    $item['html'] = self::prepare_card_markup($item);
+                    return $item;
+                },
+                $all_items
+            )),
+            'activeLetter' => $active_letter,
+            'searchTerm'   => $search_term,
+        ];
+
+        $output = '<div class="ap-orgs-dir" data-per-page="' . esc_attr((string) $per_page) . '" data-total-pages="' . esc_attr((string) $total_pages) . '">';
+        $output .= self::render_alphabet_bar($letters, $active_letter, $base_url);
+
+        if ($show_search) {
+            $output .= self::render_search_form($search_term, $active_letter);
+        }
+
+        $output .= '<div class="ap-orgs-dir__summary">' . sprintf(
+            /* translators: %s is number of organizations */
+            esc_html(_n('%s organization found', '%s organizations found', $total_results, 'artpulse')),
+            esc_html(number_format_i18n($total_results))
+        ) . '</div>';
+
+        $output .= '<div class="ap-grid" role="region" aria-live="polite" aria-busy="false">' . implode('', $visible_markup) . '</div>';
+        $output .= '<div class="ap-orgs-dir__empty" role="note"' . ($total_results > 0 ? ' hidden' : '') . '>' . esc_html__('No organizations found.', 'artpulse') . '</div>';
+
+        if ($total_pages > 1) {
+            $output .= self::render_pagination($page, $total_pages, $base_url, $active_letter, $search_term);
+        }
+
+        $output .= '<script type="application/json" class="ap-orgs-dir__data">' . wp_json_encode($json_data) . '</script>';
+        $output .= '</div>';
+
+        return $output;
+    }
+
+    public static function get_normalized_letter(string $name): string
+    {
+        $name = trim($name);
+        if ($name === '') {
+            return '#';
+        }
+
+        $name = preg_replace('/^(?:the|a|an)\s+/i', '', $name) ?? $name;
+        $name = trim($name);
+
+        if ($name === '') {
+            return '#';
+        }
+
+        if (function_exists('remove_accents')) {
+            $name = remove_accents($name);
+        }
+
+        $first_char = strtoupper(substr($name, 0, 1));
+
+        if (preg_match('/[A-Z]/', $first_char)) {
+            return $first_char;
+        }
+
+        return '#';
+    }
+
+    private static function normalize_letter_query(string $letter, array $letters): string
+    {
+        if ($letter === '') {
+            return in_array('All', $letters, true) ? 'All' : ($letters[0] ?? 'All');
+        }
+
+        $upper = strtoupper($letter);
+        if ('ALL' === $upper) {
+            return 'All';
+        }
+
+        if ('#' === $letter) {
+            return '#';
+        }
+
+        foreach ($letters as $candidate) {
+            if (strtoupper($candidate) === $upper) {
+                return $candidate;
+            }
+        }
+
+        return in_array('All', $letters, true) ? 'All' : ($letters[0] ?? 'All');
+    }
+
+    private static function parse_letters(string $letters): array
+    {
+        $letters = strtoupper($letters);
+        $parts = preg_split('/[|,]/', $letters) ?: [];
+        $output = [];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                continue;
+            }
+
+            if ('A-Z' === $part) {
+                $output = array_merge($output, range('A', 'Z'));
+                continue;
+            }
+
+            if ('ALL' === $part) {
+                $output[] = 'All';
+                continue;
+            }
+
+            if ('#' === $part) {
+                $output[] = '#';
+                continue;
+            }
+
+            if (strlen($part) === 1 && ctype_alpha($part)) {
+                $output[] = strtoupper($part);
+            }
+        }
+
+        if (empty($output)) {
+            $output = array_merge(range('A', 'Z'), ['All']);
+        }
+
+        $output = array_values(array_unique($output));
+
+        if (!in_array('All', $output, true)) {
+            array_unshift($output, 'All');
+        }
+
+        return $output;
+    }
+
+    private static function parse_taxonomy_attribute(string $taxonomy): array
+    {
+        $taxonomy = trim($taxonomy);
+        if ($taxonomy === '') {
+            return [];
+        }
+
+        $parts = array_map('trim', explode(':', $taxonomy));
+        if (count($parts) < 2) {
+            return [];
+        }
+
+        [$tax_name, $term_value] = $parts;
+        if ($tax_name === '' || $term_value === '') {
+            return [];
+        }
+
+        return [
+            'taxonomy' => sanitize_key($tax_name),
+            'field'    => is_numeric($term_value) ? 'term_id' : 'slug',
+            'terms'    => is_numeric($term_value) ? [(int) $term_value] : [sanitize_title($term_value)],
+        ];
+    }
+
+    private static function is_truthy($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $value = strtolower((string) $value);
+        return !in_array($value, ['false', '0', 'no', 'off'], true);
+    }
+
+    private static function get_post_type_slug(): string
+    {
+        static $slug = null;
+
+        if (null !== $slug) {
+            return $slug;
+        }
+
+        $candidates = apply_filters('artpulse_orgs_directory_post_types', [
+            'artpulse_org',
+            'organisation',
+            'organization',
+        ]);
+
+        foreach ($candidates as $candidate) {
+            if (post_type_exists($candidate)) {
+                $slug = $candidate;
+                return $slug;
+            }
+        }
+
+        $slug = 'artpulse_org';
+        return $slug;
+    }
+
+    private static function get_all_items(string $post_type, array $taxonomy_filter, string $search_term): array
+    {
+        $cache_key = self::TRANSIENT_ALL_PREFIX . md5($post_type . '|' . self::serialize_tax_filter($taxonomy_filter) . '|' . $search_term);
+        $cached = get_transient($cache_key);
+        if (false !== $cached) {
+            return $cached;
+        }
+
+        $query_args = [
+            'post_type'      => $post_type,
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+            'fields'         => 'ids',
+            'no_found_rows'  => true,
+        ];
+
+        if ($search_term !== '') {
+            $query_args['s'] = $search_term;
+        }
+
+        if (!empty($taxonomy_filter)) {
+            $query_args['tax_query'] = [
+                [
+                    'taxonomy' => $taxonomy_filter['taxonomy'],
+                    'field'    => $taxonomy_filter['field'],
+                    'terms'    => $taxonomy_filter['terms'],
+                ],
+            ];
+        }
+
+        $query_args = apply_filters('artpulse_orgs_directory_query_args', $query_args, [
+            'taxonomy'   => $taxonomy_filter,
+            'search'     => $search_term,
+            'post_type'  => $post_type,
+        ]);
+
+        $query = new WP_Query($query_args);
+
+        $items = [];
+
+        foreach ($query->posts as $post_id) {
+            $post_id = (int) $post_id;
+            $display_name = self::get_display_name($post_id);
+            $letter = self::get_normalized_letter($display_name);
+            $permalink = get_permalink($post_id);
+            $thumbnail = get_the_post_thumbnail_url($post_id, 'medium');
+            $excerpt = self::get_excerpt($post_id);
+
+            $badges = self::get_badges($post_id, $taxonomy_filter);
+
+            $fields = [
+                'id'           => $post_id,
+                'name'         => $display_name,
+                'letter'       => $letter,
+                'permalink'    => $permalink,
+                'thumbnail'    => $thumbnail,
+                'excerpt'      => $excerpt,
+                'badges'       => $badges,
+                'search_index' => strtolower($display_name . ' ' . implode(' ', $badges) . ' ' . $excerpt),
+                'sort_key'     => strtolower($display_name),
+            ];
+
+            $fields = apply_filters('artpulse_orgs_directory_fields', $fields, $post_id);
+
+            $items[] = $fields;
+        }
+
+        usort(
+            $items,
+            static function ($a, $b) {
+                return strcmp($a['sort_key'], $b['sort_key']);
+            }
+        );
+
+        set_transient($cache_key, $items, HOUR_IN_SECONDS);
+
+        return $items;
+    }
+
+    private static function get_paginated_ids(array $items, string $letter, int $per_page, int $page, array $taxonomy_filter, string $search_term): array
+    {
+        $cache_key = self::TRANSIENT_PREFIX . md5(
+            $letter . '|' . self::serialize_tax_filter($taxonomy_filter) . '|' . $page . '|' . $per_page . '|' . $search_term
+        );
+
+        $cached = get_transient($cache_key);
+        if (false !== $cached) {
+            return $cached;
+        }
+
+        $filtered = array_values(array_filter(
+            $items,
+            static function ($item) use ($letter) {
+                if ('All' === $letter) {
+                    return true;
+                }
+
+                return $item['letter'] === $letter;
+            }
+        ));
+
+        $total = count($filtered);
+        $total_pages = max(1, (int) ceil($total / $per_page));
+        $page = max(1, min($page, $total_pages));
+
+        $offset = ($page - 1) * $per_page;
+        $paged_items = array_slice($filtered, $offset, $per_page);
+
+        $result = [
+            'ids'         => array_map(
+                static function ($item) {
+                    return (int) $item['id'];
+                },
+                $paged_items
+            ),
+            'total'       => $total,
+            'total_pages' => $total_pages,
+        ];
+
+        set_transient($cache_key, $result, HOUR_IN_SECONDS);
+
+        return $result;
+    }
+
+    private static function render_alphabet_bar(array $letters, string $active_letter, string $base_url): string
+    {
+        $output = '<ul class="ap-az" role="list">';
+        foreach ($letters as $letter) {
+            $is_active = ($letter === $active_letter);
+            $url = add_query_arg(
+                ['letter' => 'All' === $letter ? null : $letter, 'page' => null],
+                $base_url
+            );
+            $output .= '<li>';
+            $output .= '<a class="ap-az__link' . ($is_active ? ' is-active' : '') . '" data-letter="' . esc_attr($letter) . '" href="' . esc_url($url) . '" role="button"';
+            if ($is_active) {
+                $output .= ' aria-current="true"';
+            }
+            $output .= '>' . esc_html($letter) . '</a>';
+            $output .= '</li>';
+        }
+        $output .= '</ul>';
+
+        return $output;
+    }
+
+    private static function render_search_form(string $search_term, string $active_letter): string
+    {
+        $output = '<form class="ap-orgs-dir__search" method="get" role="search">';
+        $output .= '<label class="screen-reader-text" for="ap-orgs-dir-search">' . esc_html__('Search organizations', 'artpulse') . '</label>';
+        $output .= '<input type="search" id="ap-orgs-dir-search" name="search" value="' . esc_attr($search_term) . '" placeholder="' . esc_attr__('Search organizations…', 'artpulse') . '" />';
+        $output .= '<input type="hidden" name="letter" value="' . esc_attr($active_letter) . '" />';
+        $output .= '<button type="submit" class="ap-orgs-dir__submit">' . esc_html__('Search', 'artpulse') . '</button>';
+        $output .= '</form>';
+
+        return $output;
+    }
+
+    private static function render_pagination(int $current_page, int $total_pages, string $base_url, string $active_letter, string $search_term): string
+    {
+        $output = '<nav class="ap-orgs-dir__pagination" aria-label="' . esc_attr__('Organizations pagination', 'artpulse') . '">';
+        $output .= '<ul class="ap-orgs-dir__pagination-list">';
+
+        for ($page = 1; $page <= $total_pages; $page++) {
+            $url = add_query_arg(
+                [
+                    'page'   => $page,
+                    'letter' => 'All' === $active_letter ? null : $active_letter,
+                    'search' => $search_term !== '' ? $search_term : null,
+                ],
+                $base_url
+            );
+
+            $output .= '<li>';
+            $output .= '<a class="ap-orgs-dir__page-link' . ($page === $current_page ? ' is-active' : '') . '" href="' . esc_url($url) . '"' . ($page === $current_page ? ' aria-current="true"' : '') . '>' . esc_html((string) $page) . '</a>';
+            $output .= '</li>';
+        }
+
+        $output .= '</ul>';
+        $output .= '</nav>';
+
+        return $output;
+    }
+
+    private static function get_current_url(): string
+    {
+        $request_uri = isset($_SERVER['REQUEST_URI']) ? wp_unslash((string) $_SERVER['REQUEST_URI']) : '';
+        if ($request_uri === '') {
+            return '';
+        }
+
+        $scheme = is_ssl() ? 'https' : 'http';
+        $host = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash((string) $_SERVER['HTTP_HOST'])) : '';
+        return esc_url_raw($scheme . '://' . $host . $request_uri);
+    }
+
+    private static function get_display_name(int $post_id): string
+    {
+        $candidates = [
+            'org_display_name',
+            '_org_display_name',
+            'ap_org_display_name',
+            '_ap_org_display_name',
+        ];
+
+        foreach ($candidates as $meta_key) {
+            $value = get_post_meta($post_id, $meta_key, true);
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        $title = get_post_field('post_title', $post_id);
+        return is_string($title) ? $title : '';
+    }
+
+    private static function get_excerpt(int $post_id): string
+    {
+        $excerpt = get_post_field('post_excerpt', $post_id);
+        if (!is_string($excerpt) || $excerpt === '') {
+            $content = get_post_field('post_content', $post_id);
+            $excerpt = is_string($content) ? wp_strip_all_tags($content) : '';
+        }
+
+        return wp_html_excerpt($excerpt, 140, '&hellip;');
+    }
+
+    private static function get_badges(int $post_id, array $taxonomy_filter): array
+    {
+        $badges = [];
+
+        $address = get_post_meta($post_id, '_ap_org_address', true);
+        if (is_string($address) && $address !== '') {
+            $badges[] = $address;
+        }
+
+        $taxonomies = ['organization_category'];
+        if (!empty($taxonomy_filter)) {
+            $taxonomies[] = $taxonomy_filter['taxonomy'];
+        }
+
+        $taxonomies = array_unique(array_filter($taxonomies));
+
+        foreach ($taxonomies as $taxonomy) {
+            $terms = get_the_terms($post_id, $taxonomy);
+            if (is_array($terms)) {
+                foreach ($terms as $term) {
+                    $badges[] = $term->name;
+                }
+            }
+        }
+
+        return array_values(array_unique(array_filter($badges, static function ($badge) {
+            return is_string($badge) && $badge !== '';
+        })));
+    }
+
+    private static function prepare_card_markup(array $item): string
+    {
+        $classes = ['ap-card'];
+        $classes[] = 'ap-card--letter-' . sanitize_html_class(strtolower($item['letter']));
+
+        $attributes = [
+            'class'       => implode(' ', array_map('sanitize_html_class', $classes)),
+            'data-letter' => $item['letter'],
+            'data-search' => $item['search_index'],
+        ];
+
+        $html = '<article';
+        foreach ($attributes as $key => $value) {
+            $html .= ' ' . $key . '="' . esc_attr($value) . '"';
+        }
+        $html .= '>';
+
+        if (!empty($item['thumbnail'])) {
+            $html .= '<div class="ap-card__thumb"><img src="' . esc_url($item['thumbnail']) . '" alt="" loading="lazy" /></div>';
+        }
+
+        $html .= '<div class="ap-card__body">';
+        $html .= '<h3 class="ap-card__title"><a href="' . esc_url($item['permalink']) . '">' . esc_html($item['name']) . '</a></h3>';
+
+        if (!empty($item['excerpt'])) {
+            $html .= '<p class="ap-card__excerpt">' . esc_html($item['excerpt']) . '</p>';
+        }
+
+        if (!empty($item['badges'])) {
+            $html .= '<div class="ap-card__badges">';
+            foreach ($item['badges'] as $badge) {
+                $html .= '<span class="ap-badge">' . esc_html($badge) . '</span>';
+            }
+            $html .= '</div>';
+        }
+
+        if (!empty($item['is_favorited'])) {
+            $html .= '<div class="ap-card__favorite">' . esc_html__('★ Favorited', 'artpulse') . '</div>';
+        }
+
+        $html .= '</div>';
+        $html .= '</article>';
+
+        return $html;
+    }
+
+    private static function serialize_tax_filter(array $taxonomy_filter): string
+    {
+        if (empty($taxonomy_filter)) {
+            return '';
+        }
+
+        return $taxonomy_filter['taxonomy'] . ':' . implode(',', $taxonomy_filter['terms']);
+    }
+}

--- a/tests/Frontend/OrgsDirectoryTest.php
+++ b/tests/Frontend/OrgsDirectoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ArtPulse\Tests\Frontend;
+
+use ArtPulse\Frontend\OrgsDirectory;
+
+class OrgsDirectoryTest extends \WP_UnitTestCase
+{
+    protected function tearDown(): void
+    {
+        OrgsDirectory::flush_cache();
+        $_GET = [];
+        parent::tearDown();
+    }
+
+    public function test_normalized_letter_strips_articles(): void
+    {
+        $this->assertSame('B', OrgsDirectory::get_normalized_letter('The Blue Whale'));
+        $this->assertSame('A', OrgsDirectory::get_normalized_letter('An Apple Farm'));
+        $this->assertSame('#', OrgsDirectory::get_normalized_letter('123 Collective'));
+    }
+
+    public function test_taxonomy_filter_limits_results(): void
+    {
+        $music = wp_insert_term('Music', 'organization_category');
+        $visual = wp_insert_term('Visual', 'organization_category');
+
+        $this->assertFalse(is_wp_error($music));
+        $this->assertFalse(is_wp_error($visual));
+        $this->assertIsArray($music);
+        $this->assertIsArray($visual);
+
+        $alpha = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_status' => 'publish',
+            'post_title'  => 'Alpha Arts',
+        ]);
+        $beta = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_status' => 'publish',
+            'post_title'  => 'Beta Collective',
+        ]);
+
+        wp_set_object_terms($alpha, [$music['term_id']], 'organization_category');
+        wp_set_object_terms($beta, [$visual['term_id']], 'organization_category');
+
+        $_GET['letter'] = 'All';
+
+        $output = do_shortcode('[ap_orgs_directory taxonomy="organization_category:' . $music['term_id'] . '" show_search="false" letters="A,B,All"]');
+
+        $this->assertStringContainsString('Alpha Arts', $output);
+        $this->assertStringNotContainsString('Beta Collective', $output);
+    }
+
+    public function test_pagination_respects_page_query(): void
+    {
+        $first = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_status' => 'publish',
+            'post_title'  => 'Atlas Center',
+        ]);
+        $second = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_status' => 'publish',
+            'post_title'  => 'Beacon Arts',
+        ]);
+        $third = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_status' => 'publish',
+            'post_title'  => 'Civic Studio',
+        ]);
+
+        $this->assertNotEquals(0, $first + $second + $third);
+
+        $_GET['letter'] = 'All';
+        $_GET['page'] = 2;
+
+        $output = do_shortcode('[ap_orgs_directory per_page="1" show_search="false" letters="A-Z,All"]');
+
+        $this->assertStringContainsString('Beacon Arts', $output);
+        $this->assertStringNotContainsString('Atlas Center', $output);
+        $this->assertStringNotContainsString('Civic Studio', $output);
+    }
+}

--- a/tests/e2e/orgs-directory.spec.js
+++ b/tests/e2e/orgs-directory.spec.js
@@ -1,0 +1,131 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8889';
+
+async function runWpCli(args, { ignoreError = false } = {}) {
+  try {
+    const { stdout } = await execFileAsync('npx', ['wp-env', 'run', 'tests-cli', ...args], {
+      env: process.env,
+    });
+    return stdout.trim();
+  } catch (error) {
+    if (ignoreError) {
+      const stdout = error.stdout ? error.stdout.toString() : '';
+      return stdout.trim();
+    }
+    throw error;
+  }
+}
+
+describe('Organizations directory shortcode', () => {
+  const createdOrgIds = [];
+  let pageId = 0;
+  let favoritesEnabled = false;
+
+  beforeAll(async () => {
+    const orgs = [
+      { title: 'Art Guild' },
+      { title: 'The Blue Whale' },
+      { title: 'Civic Collective' },
+    ];
+
+    for (const org of orgs) {
+      const idOutput = await runWpCli([
+        'wp',
+        'post',
+        'create',
+        '--post_type=artpulse_org',
+        `--post_title=${org.title}`,
+        '--post_status=publish',
+        '--porcelain',
+      ]);
+      const orgId = parseInt(idOutput, 10);
+      expect(Number.isNaN(orgId)).toBe(false);
+      createdOrgIds.push(orgId);
+    }
+
+    const pageOutput = await runWpCli([
+      'wp',
+      'post',
+      'create',
+      '--post_type=page',
+      '--post_title=Organizations Directory Test Page',
+      '--post_status=publish',
+      '--post_content=[ap_orgs_directory]',
+      '--porcelain',
+    ]);
+    pageId = parseInt(pageOutput, 10);
+    expect(Number.isNaN(pageId)).toBe(false);
+
+    const favoritesCheck = await runWpCli([
+      'wp',
+      'eval',
+      "echo class_exists('\\\\ArtPulse\\\\Community\\\\FavoritesManager') ? '1' : '0';",
+    ]);
+    favoritesEnabled = favoritesCheck.trim() === '1';
+
+    if (favoritesEnabled) {
+      await runWpCli([
+        'wp',
+        'eval',
+        `ArtPulse\\\\Community\\\\FavoritesManager::add_favorite(1, ${createdOrgIds[0]}, 'artpulse_org'); echo 'done';`,
+      ]);
+    }
+  });
+
+  afterAll(async () => {
+    if (pageId) {
+      await runWpCli(['wp', 'post', 'delete', String(pageId), '--force'], { ignoreError: true });
+    }
+
+    for (const orgId of createdOrgIds) {
+      await runWpCli(['wp', 'post', 'delete', String(orgId), '--force'], { ignoreError: true });
+    }
+  });
+
+  it('filters organizations by letter and search', async () => {
+    await page.goto(`${BASE_URL}/wp-login.php`);
+    await page.fill('#user_login', 'admin');
+    await page.fill('#user_pass', 'password');
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('#wp-submit'),
+    ]);
+
+    await page.goto(`${BASE_URL}/?p=${pageId}`);
+    await page.waitForSelector('.ap-orgs-dir');
+    await page.waitForSelector('.ap-grid .ap-card');
+
+    const letterB = await page.waitForSelector('.ap-az__link[data-letter="B"]');
+    await letterB.click();
+
+    await page.waitForFunction(() => {
+      const titles = Array.from(document.querySelectorAll('.ap-grid .ap-card__title')).map((el) => el.textContent.trim());
+      return titles.length === 1 && titles[0] === 'The Blue Whale';
+    });
+
+    const visibleAfterLetter = await page.$$eval('.ap-grid .ap-card__title', (nodes) => nodes.map((node) => node.textContent.trim()));
+    expect(visibleAfterLetter).toEqual(['The Blue Whale']);
+
+    const letterAll = await page.waitForSelector('.ap-az__link[data-letter="All"]');
+    await letterAll.click();
+
+    await page.waitForFunction(() => {
+      const titles = Array.from(document.querySelectorAll('.ap-grid .ap-card__title')).map((el) => el.textContent.trim());
+      return titles.length >= 3;
+    });
+
+    if (favoritesEnabled) {
+      const starExists = await page.$eval('.ap-grid .ap-card__favorite', () => true).catch(() => false);
+      expect(starExists).toBe(true);
+    }
+
+    await page.fill('#ap-orgs-dir-search', 'Civic');
+    await page.waitForFunction(() => {
+      const titles = Array.from(document.querySelectorAll('.ap-grid .ap-card__title')).map((el) => el.textContent.trim());
+      return titles.length === 1 && titles[0] === 'Civic Collective';
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `OrgsDirectory` frontend module that provides the `[ap_orgs_directory]` shortcode with caching, taxonomy filtering, pagination, and favorites-aware rendering
- ship dedicated CSS/JS to deliver the accessible A–Z directory UI with client-side search/letter filtering and URL updates
- cover the feature with unit and Playwright specs plus README usage examples and core registration wiring

## Testing
- [ ] `vendor/bin/phpunit` *(blocked: Composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1637a150c832eae690eff5da1ad54