### PR TITLE
Add member dashboard upgrade prompts

### DIFF
--- a/assets/css/ap-user-dashboard.css
+++ b/assets/css/ap-user-dashboard.css
@@ -272,6 +272,63 @@
   color: #1f2933;
 }
 
+.ap-dashboard-section--upgrades {
+  background: linear-gradient(135deg, #0f172a, #1d4ed8);
+  color: #f8fafc;
+}
+
+.ap-dashboard-section--upgrades > h3 {
+  color: inherit;
+}
+
+.ap-dashboard-upgrades__intro {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.ap-dashboard-upgrades {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.ap-dashboard-upgrade {
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  border: 1px solid rgba(248, 250, 252, 0.2);
+}
+
+.ap-dashboard-upgrade__body {
+  gap: 0.75rem;
+}
+
+.ap-dashboard-upgrade__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.ap-dashboard-upgrade__description {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.ap-dashboard-section--upgrades .ap-dashboard-card__actions {
+  padding: 0 1.25rem 1.25rem;
+}
+
+.ap-dashboard-section--upgrades .ap-dashboard-button--primary {
+  background-color: #facc15;
+  color: #0f172a;
+}
+
+.ap-dashboard-section--upgrades .ap-dashboard-button--primary:hover,
+.ap-dashboard-section--upgrades .ap-dashboard-button--primary:focus {
+  background-color: #fde047;
+  color: #0f172a;
+}
+
 .ap-dashboard-card {
   display: flex;
   flex-direction: column;
@@ -323,6 +380,59 @@
 
 .ap-dashboard-card__actions .ap-dashboard-button {
   margin: 0;
+}
+
+.ap-dashboard-widget__section--upgrades {
+  background: linear-gradient(135deg, #0f172a, #1d4ed8);
+  color: #f8fafc;
+}
+
+.ap-dashboard-widget__section--upgrades h3 {
+  color: inherit;
+}
+
+.ap-dashboard-widget__upgrade-intro {
+  margin: 0 0 1rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.ap-dashboard-widget__upgrades {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.ap-dashboard-widget__upgrade-card {
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(248, 250, 252, 0.2);
+  border-radius: 10px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ap-dashboard-widget__upgrade-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.ap-dashboard-widget__upgrade-description {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.ap-dashboard-widget__upgrade-card .ap-dashboard-button--primary {
+  align-self: flex-start;
+  background-color: #facc15;
+  color: #0f172a;
+}
+
+.ap-dashboard-widget__upgrade-card .ap-dashboard-button--primary:hover,
+.ap-dashboard-widget__upgrade-card .ap-dashboard-button--primary:focus {
+  background-color: #fde047;
+  color: #0f172a;
 }
 
 .ap-dashboard-empty {

--- a/assets/js/ap-dashboards.js
+++ b/assets/js/ap-dashboards.js
@@ -100,6 +100,11 @@
     grid.className = 'ap-dashboard-grid';
 
     grid.appendChild(buildProfileSection(data.profile, roleLabels.profile));
+
+    if (role === 'member' && Array.isArray(data.upgrades) && data.upgrades.length) {
+      grid.appendChild(buildUpgradeSection(data.upgrades, roleLabels.upgrades, data.upgrade_intro));
+    }
+
     grid.appendChild(buildMetricsSection(data.metrics, roleLabels.metrics));
     grid.appendChild(buildSubmissionsSection(data.submissions, roleLabels.submissions));
     grid.appendChild(buildFavoritesSection(data.favorites, roleLabels.favorites));
@@ -134,6 +139,75 @@
     `;
 
     section.appendChild(card);
+    return section;
+  }
+
+  function buildUpgradeSection(upgrades = [], titleOverride, introText) {
+    const section = createSection('upgrades', titleOverride || strings.upgrades || 'Membership Upgrades');
+
+    if (!Array.isArray(upgrades) || upgrades.length === 0) {
+      section.appendChild(createEmptyState());
+      return section;
+    }
+
+    const introCopy = introText || strings.upgradeIntro;
+    if (introCopy) {
+      const intro = document.createElement('p');
+      intro.className = 'ap-dashboard-upgrades__intro';
+      intro.textContent = introCopy;
+      section.appendChild(intro);
+    }
+
+    const list = document.createElement('div');
+    list.className = 'ap-dashboard-upgrades';
+
+    upgrades.forEach((upgrade) => {
+      if (!upgrade || !upgrade.url) {
+        return;
+      }
+
+      const card = document.createElement('article');
+      card.className = 'ap-dashboard-card ap-dashboard-upgrade';
+
+      const body = document.createElement('div');
+      body.className = 'ap-dashboard-card__body ap-dashboard-upgrade__body';
+
+      if (upgrade.title) {
+        const title = document.createElement('h4');
+        title.className = 'ap-dashboard-upgrade__title';
+        title.textContent = upgrade.title;
+        body.appendChild(title);
+      }
+
+      if (upgrade.description) {
+        const desc = document.createElement('p');
+        desc.className = 'ap-dashboard-upgrade__description';
+        desc.textContent = upgrade.description;
+        body.appendChild(desc);
+      }
+
+      card.appendChild(body);
+
+      const actions = document.createElement('div');
+      actions.className = 'ap-dashboard-card__actions';
+
+      const link = document.createElement('a');
+      link.className = 'ap-dashboard-button ap-dashboard-button--primary';
+      link.href = upgrade.url;
+      link.textContent = upgrade.cta || strings.upgradeCta || 'Upgrade now';
+
+      actions.appendChild(link);
+      card.appendChild(actions);
+
+      list.appendChild(card);
+    });
+
+    if (!list.children.length) {
+      section.appendChild(createEmptyState());
+      return section;
+    }
+
+    section.appendChild(list);
     return section;
   }
 

--- a/templates/dashboard/widget.php
+++ b/templates/dashboard/widget.php
@@ -10,8 +10,10 @@ $profile     = $dashboard['profile'] ?? [];
 $metrics     = $dashboard['metrics'] ?? [];
 $favorites   = array_slice($dashboard['favorites'] ?? [], 0, 5);
 $follows     = array_slice($dashboard['follows'] ?? [], 0, 5);
-$submissions = $dashboard['submissions'] ?? [];
-$membership  = $profile['membership'] ?? [];
+$submissions   = $dashboard['submissions'] ?? [];
+$membership    = $profile['membership'] ?? [];
+$upgrades      = $dashboard['upgrades'] ?? [];
+$upgrade_intro = $dashboard['upgrade_intro'] ?? '';
 
 $metric_labels = [
     'favorites'             => esc_html__('Favorites', 'artpulse'),
@@ -124,6 +126,37 @@ $metric_labels = [
                     <?php endif; ?>
                 </div>
             <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($upgrades)) : ?>
+        <div class="ap-dashboard-widget__section ap-dashboard-widget__section--upgrades">
+            <h3><?php esc_html_e('Membership Upgrades', 'artpulse'); ?></h3>
+
+            <?php if (!empty($upgrade_intro)) : ?>
+                <p class="ap-dashboard-widget__upgrade-intro"><?php echo esc_html($upgrade_intro); ?></p>
+            <?php endif; ?>
+
+            <div class="ap-dashboard-widget__upgrades">
+                <?php foreach ($upgrades as $upgrade) :
+                    $url  = $upgrade['url'] ?? '';
+                    if (empty($url)) {
+                        continue;
+                    }
+                    ?>
+                    <div class="ap-dashboard-widget__upgrade-card">
+                        <h4 class="ap-dashboard-widget__upgrade-title"><?php echo esc_html($upgrade['title'] ?? ''); ?></h4>
+
+                        <?php if (!empty($upgrade['description'])) : ?>
+                            <p class="ap-dashboard-widget__upgrade-description"><?php echo esc_html($upgrade['description']); ?></p>
+                        <?php endif; ?>
+
+                        <a class="ap-dashboard-button ap-dashboard-button--primary" href="<?php echo esc_url($url); ?>">
+                            <?php echo esc_html($upgrade['cta'] ?? __('Upgrade now', 'artpulse')); ?>
+                        </a>
+                    </div>
+                <?php endforeach; ?>
+            </div>
         </div>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- add membership upgrade data for member dashboards including purchase URLs and localized copy
- render upgrade calls-to-action in both PHP widget output and the JavaScript dashboard renderer
- style the upgrade cards to align with existing dashboard visuals

## Testing
- php -l src/Core/RoleDashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68e22269bf18832ea3850edef906c8c5