### PR TITLE
Add member upgrade dashboard widget with shared template

### DIFF
--- a/templates/dashboard/partials/upgrade-section.php
+++ b/templates/dashboard/partials/upgrade-section.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Upgrade section template shared across dashboard widgets.
+ *
+ * @var string $section_title    Title for the upgrade section.
+ * @var string $section_intro    Introductory copy for the upgrade section.
+ * @var array  $section_upgrades List of available upgrades.
+ */
+?>
+<div class="ap-dashboard-widget__section ap-dashboard-widget__section--upgrades">
+    <h3><?php echo esc_html($section_title); ?></h3>
+
+    <?php if ($section_intro !== '') : ?>
+        <p class="ap-dashboard-widget__upgrade-intro"><?php echo esc_html($section_intro); ?></p>
+    <?php endif; ?>
+
+    <div class="ap-dashboard-widget__upgrades">
+        <?php foreach ($section_upgrades as $upgrade) :
+            $url = $upgrade['url'] ?? '';
+
+            if ($url === '') {
+                continue;
+            }
+            ?>
+            <div class="ap-dashboard-widget__upgrade-card">
+                <?php if (!empty($upgrade['title'])) : ?>
+                    <h4 class="ap-dashboard-widget__upgrade-title"><?php echo esc_html($upgrade['title']); ?></h4>
+                <?php endif; ?>
+
+                <?php if (!empty($upgrade['description'])) : ?>
+                    <p class="ap-dashboard-widget__upgrade-description"><?php echo esc_html($upgrade['description']); ?></p>
+                <?php endif; ?>
+
+                <a class="ap-dashboard-button ap-dashboard-button--primary" href="<?php echo esc_url($url); ?>">
+                    <?php echo esc_html($upgrade['cta'] ?? __('Upgrade now', 'artpulse')); ?>
+                </a>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>

--- a/templates/dashboard/widget.php
+++ b/templates/dashboard/widget.php
@@ -129,34 +129,5 @@ $metric_labels = [
         </div>
     <?php endif; ?>
 
-    <?php if (!empty($upgrades)) : ?>
-        <div class="ap-dashboard-widget__section ap-dashboard-widget__section--upgrades">
-            <h3><?php esc_html_e('Membership Upgrades', 'artpulse'); ?></h3>
-
-            <?php if (!empty($upgrade_intro)) : ?>
-                <p class="ap-dashboard-widget__upgrade-intro"><?php echo esc_html($upgrade_intro); ?></p>
-            <?php endif; ?>
-
-            <div class="ap-dashboard-widget__upgrades">
-                <?php foreach ($upgrades as $upgrade) :
-                    $url  = $upgrade['url'] ?? '';
-                    if (empty($url)) {
-                        continue;
-                    }
-                    ?>
-                    <div class="ap-dashboard-widget__upgrade-card">
-                        <h4 class="ap-dashboard-widget__upgrade-title"><?php echo esc_html($upgrade['title'] ?? ''); ?></h4>
-
-                        <?php if (!empty($upgrade['description'])) : ?>
-                            <p class="ap-dashboard-widget__upgrade-description"><?php echo esc_html($upgrade['description']); ?></p>
-                        <?php endif; ?>
-
-                        <a class="ap-dashboard-button ap-dashboard-button--primary" href="<?php echo esc_url($url); ?>">
-                            <?php echo esc_html($upgrade['cta'] ?? __('Upgrade now', 'artpulse')); ?>
-                        </a>
-                    </div>
-                <?php endforeach; ?>
-            </div>
-        </div>
-    <?php endif; ?>
+    <?php echo \ArtPulse\Core\RoleDashboards::renderUpgradeWidgetSection($upgrades, $upgrade_intro); ?>
 </div>


### PR DESCRIPTION
## Summary
- register a dedicated dashboard widget for membership upgrades when options are available
- extract the upgrade markup into a shared partial that both widgets can reuse
- ensure the widget loads the existing dashboard assets and styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e226255704832e8bdee62c994175c0