### PR TITLE
Add reusable upgrade widget wrapper for dashboards

### DIFF
--- a/src/Core/RoleDashboards.php
+++ b/src/Core/RoleDashboards.php
@@ -104,7 +104,7 @@ class RoleDashboards
                             return;
                         }
 
-                        echo self::renderUpgradeWidgetSection(
+                        echo self::renderUpgradeWidget(
                             $upgrades,
                             $member_dashboard['upgrade_intro'] ?? ''
                         );
@@ -598,6 +598,57 @@ class RoleDashboards
 
         $dashboard = $data;
         $role      = $data['role'] ?? '';
+
+        include $template;
+
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * Render the upgrade widget container that wraps the shared upgrade section.
+     *
+     * @param array       $upgrades    Upgrades to display.
+     * @param string      $intro       Introductory copy shown within the section.
+     * @param string|null $title       Optional title for the upgrade section.
+     * @param array       $widget_args Optional arguments for the widget wrapper. Supports 'title' and 'intro'.
+     */
+    public static function renderUpgradeWidget(array $upgrades, string $intro = '', ?string $title = null, array $widget_args = []): string
+    {
+        if (empty($upgrades)) {
+            return '';
+        }
+
+        $template = dirname(__DIR__, 2) . '/templates/dashboard/upgrade-widget.php';
+
+        $widget_title = isset($widget_args['title']) && is_string($widget_args['title'])
+            ? $widget_args['title']
+            : '';
+        $widget_intro = isset($widget_args['intro']) && is_string($widget_args['intro'])
+            ? $widget_args['intro']
+            : '';
+
+        if (!file_exists($template)) {
+            $output = '<div class="ap-upgrade-widget">';
+
+            if ($widget_title !== '') {
+                $output .= sprintf('<h2 class="ap-upgrade-widget__title">%s</h2>', esc_html($widget_title));
+            }
+
+            if ($widget_intro !== '') {
+                $output .= sprintf('<p class="ap-upgrade-widget__intro">%s</p>', esc_html($widget_intro));
+            }
+
+            $output .= self::renderUpgradeWidgetSection($upgrades, $intro, $title);
+            $output .= '</div>';
+
+            return $output;
+        }
+
+        ob_start();
+
+        $widget_upgrades      = $upgrades;
+        $widget_section_intro = $intro;
+        $widget_section_title = $title;
 
         include $template;
 

--- a/templates/dashboard/upgrade-widget.php
+++ b/templates/dashboard/upgrade-widget.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Upgrade widget template providing a reusable wrapper for upgrade sections.
+ *
+ * @var array       $widget_upgrades       List of available upgrades.
+ * @var string      $widget_section_intro  Introductory copy for the upgrade section.
+ * @var string|null $widget_section_title  Title for the upgrade section.
+ * @var string      $widget_title          Optional title displayed above the section wrapper.
+ * @var string      $widget_intro          Optional intro displayed above the section wrapper.
+ */
+?>
+<div class="ap-upgrade-widget">
+    <?php if ($widget_title !== '') : ?>
+        <h2 class="ap-upgrade-widget__title"><?php echo esc_html($widget_title); ?></h2>
+    <?php endif; ?>
+
+    <?php if ($widget_intro !== '') : ?>
+        <p class="ap-upgrade-widget__intro"><?php echo esc_html($widget_intro); ?></p>
+    <?php endif; ?>
+
+    <?php echo \ArtPulse\Core\RoleDashboards::renderUpgradeWidgetSection(
+        $widget_upgrades,
+        $widget_section_intro,
+        $widget_section_title
+    ); ?>
+</div>

--- a/templates/dashboard/widget.php
+++ b/templates/dashboard/widget.php
@@ -129,5 +129,5 @@ $metric_labels = [
         </div>
     <?php endif; ?>
 
-    <?php echo \ArtPulse\Core\RoleDashboards::renderUpgradeWidgetSection($upgrades, $upgrade_intro); ?>
+    <?php echo \ArtPulse\Core\RoleDashboards::renderUpgradeWidget($upgrades, $upgrade_intro); ?>
 </div>


### PR DESCRIPTION
## Summary
- add a dedicated upgrade widget template that wraps the existing upgrade cards in a reusable container
- introduce `RoleDashboards::renderUpgradeWidget()` and reuse it for frontend and admin dashboard placements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22f7737fc832eb3d7373cff9af2e5