### PR TITLE
Implement accessible A–Z directories

### DIFF
--- a/artpulse-management.php
+++ b/artpulse-management.php
@@ -4,7 +4,7 @@
  * Description:     Management plugin for ArtPulse.
  * Version:         1.1.5
  * Author:          craig
- * Text Domain:     artpulse
+ * Text Domain:     artpulse-management
  * License:         GPL2
  */
 

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -34,9 +34,12 @@ class Plugin
         register_deactivation_hook( ARTPULSE_PLUGIN_FILE, [ $this, 'deactivate' ] );
 
         \ArtPulse\Core\LoginRedirector::register();
+        \ArtPulse\Core\TitleTools::register();
+        \ArtPulse\Core\Rewrites::register();
 
         // Register core modules and front-end submission forms
         add_action( 'init',               [ $this, 'register_core_modules' ] );
+        add_action( 'init',               [ $this, 'load_textdomain' ] );
         add_action( 'init',               [ \ArtPulse\Frontend\SubmissionForms::class, 'register' ] );
         add_action( 'init',               [ \ArtPulse\Core\RoleDashboards::class, 'register' ] );
         \ArtPulse\Core\RoleSetup::register();
@@ -80,6 +83,8 @@ class Plugin
 
         // Register CPTs and flush rewrite rules
         \ArtPulse\Core\PostTypeRegistrar::register();
+        \ArtPulse\Core\Rewrites::add_rewrite_rules();
+        \ArtPulse\Core\Rewrites::register_directory_sitemap_route();
         flush_rewrite_rules();
 
         // Setup roles and capabilities
@@ -96,6 +101,11 @@ class Plugin
     {
         flush_rewrite_rules();
         wp_clear_scheduled_hook( 'ap_daily_expiry_check' );
+    }
+
+    public function load_textdomain()
+    {
+        load_plugin_textdomain( 'artpulse-management', false, dirname( plugin_basename( ARTPULSE_PLUGIN_FILE ) ) . '/languages' );
     }
 
     public function register_core_modules()

--- a/src/Core/Rewrites.php
+++ b/src/Core/Rewrites.php
@@ -1,0 +1,199 @@
+<?php
+namespace ArtPulse\Core;
+
+/**
+ * Handles custom rewrite rules and sitemap integrations for ArtPulse directories.
+ */
+class Rewrites
+{
+    private const DIRECTORY_SITEMAP_QUERY = 'ap_directory_sitemap';
+
+    /**
+     * Bootstrap the rewrite subsystem.
+     */
+    public static function register(): void
+    {
+        add_action('init', [self::class, 'add_rewrite_rules']);
+        add_action('init', [self::class, 'register_directory_sitemap_route']);
+        add_filter('query_vars', [self::class, 'register_query_vars']);
+        add_action('template_redirect', [self::class, 'maybe_render_directory_sitemap']);
+        add_filter('wpseo_sitemap_entries', [self::class, 'add_to_yoast_sitemap']);
+        add_filter('rank_math/sitemap/index/links', [self::class, 'add_to_rankmath_sitemap']);
+    }
+
+    /**
+     * Register rewrite rules for artist and gallery directory letters.
+     */
+    public static function add_rewrite_rules(): void
+    {
+        $artists_base = self::get_directory_base_slug('artists');
+        $orgs_base    = self::get_directory_base_slug('galleries');
+        $pattern      = '([A-Za-z]|%23|#|all)';
+
+        if ($artists_base !== '') {
+            add_rewrite_rule('^' . $artists_base . '/' . $pattern . '/?$', 'index.php?pagename=' . $artists_base . '&letter=$matches[1]&ap_directory=artists', 'top');
+        }
+
+        if ($orgs_base !== '') {
+            add_rewrite_rule('^' . $orgs_base . '/' . $pattern . '/?$', 'index.php?pagename=' . $orgs_base . '&letter=$matches[1]&ap_directory=galleries', 'top');
+        }
+    }
+
+    /**
+     * Register the custom sitemap endpoint.
+     */
+    public static function register_directory_sitemap_route(): void
+    {
+        add_rewrite_rule('^sitemap-artpulse-directories\.xml$', 'index.php?' . self::DIRECTORY_SITEMAP_QUERY . '=1', 'top');
+    }
+
+    /**
+     * Add query vars for rewrites and sitemap.
+     */
+    public static function register_query_vars(array $vars): array
+    {
+        $vars[] = 'letter';
+        $vars[] = 'ap_directory';
+        $vars[] = self::DIRECTORY_SITEMAP_QUERY;
+
+        return array_values(array_unique($vars));
+    }
+
+    /**
+     * Render the fallback sitemap when requested.
+     */
+    public static function maybe_render_directory_sitemap(): void
+    {
+        if ((int) get_query_var(self::DIRECTORY_SITEMAP_QUERY, 0) !== 1) {
+            return;
+        }
+
+        $urls = self::get_directory_letter_urls();
+
+        header('Content-Type: application/xml; charset=UTF-8');
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+        echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+
+        foreach ($urls as $url) {
+            echo '  <url>' . "\n";
+            echo '    <loc>' . esc_url($url) . '</loc>' . "\n";
+            echo '    <changefreq>weekly</changefreq>' . "\n";
+            echo '  </url>' . "\n";
+        }
+
+        echo '</urlset>';
+        exit;
+    }
+
+    /**
+     * Include the directory sitemap in Yoast's sitemap index.
+     */
+    public static function add_to_yoast_sitemap(array $entries): array
+    {
+        if (!function_exists('wpseo_xml_sitemaps_base_url')) {
+            return $entries;
+        }
+
+        $sitemap_url = esc_url_raw(self::get_directory_sitemap_url());
+        foreach ($entries as $entry) {
+            if (isset($entry['loc']) && $entry['loc'] === $sitemap_url) {
+                return $entries;
+            }
+        }
+
+        $entries[] = [
+            'loc'     => $sitemap_url,
+            'lastmod' => gmdate('c'),
+        ];
+
+        return $entries;
+    }
+
+    /**
+     * Include the directory sitemap in RankMath's sitemap index.
+     */
+    public static function add_to_rankmath_sitemap(array $links): array
+    {
+        $sitemap_url = esc_url_raw(self::get_directory_sitemap_url());
+        foreach ($links as $link) {
+            if (is_array($link) && isset($link['loc']) && $link['loc'] === $sitemap_url) {
+                return $links;
+            }
+        }
+
+        $links[] = [
+            'loc' => $sitemap_url,
+            'mod' => gmdate('c'),
+        ];
+
+        return $links;
+    }
+
+    /**
+     * Helper to retrieve the base slug for a directory type.
+     */
+    public static function get_directory_base_slug(string $type): string
+    {
+        $default = $type === 'artists' ? 'artists' : 'galleries';
+        $slug    = apply_filters('ap_' . $type . '_directory_base', $default);
+
+        return trim((string) $slug, '/');
+    }
+
+    /**
+     * Build the URL for a specific directory letter page.
+     */
+    public static function get_directory_letter_url(string $type, string $letter, array $query = []): string
+    {
+        $base = self::get_directory_base_slug($type);
+        if ('' === $base) {
+            return home_url('/');
+        }
+
+        $normalized = strtolower($letter) === 'all' ? 'all' : strtoupper(rawurldecode($letter));
+        if ('#' === $normalized) {
+            $segment = rawurlencode('#');
+        } elseif ('all' === strtolower($letter)) {
+            $segment = 'all';
+        } elseif (preg_match('/^[A-Z]$/', $normalized)) {
+            $segment = strtoupper($normalized);
+        } else {
+            $segment = rawurlencode('#');
+        }
+
+        $path = trailingslashit($base);
+        $path .= trailingslashit($segment);
+
+        $url = home_url('/' . ltrim($path, '/'));
+        if (!empty($query)) {
+            $url = add_query_arg($query, $url);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Return all letter URLs for both directory types.
+     */
+    public static function get_directory_letter_urls(): array
+    {
+        $letters = array_merge(['all'], range('A', 'Z'), ['#']);
+        $urls    = [];
+
+        foreach (['artists', 'galleries'] as $type) {
+            foreach ($letters as $letter) {
+                $urls[] = self::get_directory_letter_url($type, $letter);
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * URL of the combined directory sitemap.
+     */
+    public static function get_directory_sitemap_url(): string
+    {
+        return home_url('/sitemap-artpulse-directories.xml');
+    }
+}

--- a/src/Core/TitleTools.php
+++ b/src/Core/TitleTools.php
@@ -1,0 +1,138 @@
+<?php
+namespace ArtPulse\Core;
+
+/**
+ * Utilities for working with post titles within ArtPulse directories.
+ */
+class TitleTools
+{
+    public const META_KEY = '_ap_letter_key';
+
+    /**
+     * Register hooks for maintaining normalized title metadata.
+     */
+    public static function register(): void
+    {
+        add_action('save_post_artpulse_artist', [self::class, 'update_post_letter_on_save'], 10, 3);
+        add_action('save_post_artpulse_org', [self::class, 'update_post_letter_on_save'], 10, 3);
+    }
+
+    /**
+     * Normalise a title to its directory letter bucket.
+     *
+     * @param string $title  The raw post title.
+     * @param string $locale Optional locale hint.
+     */
+    public static function normalizeLetter(string $title, string $locale = ''): string
+    {
+        $title = trim($title);
+        if ('' === $title) {
+            return '#';
+        }
+
+        $locale = $locale ?: determine_locale();
+        $articles = apply_filters('ap_articles', ['the ', 'a ', 'an '], $locale);
+
+        $working = $title;
+        if (!empty($articles)) {
+            $lower = function_exists('mb_strtolower') ? mb_strtolower($working, 'UTF-8') : strtolower($working);
+            foreach ($articles as $article) {
+                $article = is_string($article) ? $article : '';
+                if ('' === $article) {
+                    continue;
+                }
+                $articleLower = function_exists('mb_strtolower') ? mb_strtolower($article, 'UTF-8') : strtolower($article);
+                $length = function_exists('mb_strlen') ? mb_strlen($articleLower, 'UTF-8') : strlen($articleLower);
+                if ($length > 0 && 0 === strpos($lower, $articleLower)) {
+                    $working = ltrim(function_exists('mb_substr') ? mb_substr($working, $length, null, 'UTF-8') : substr($working, $length));
+                    break;
+                }
+            }
+        }
+
+        if ('' === $working) {
+            return '#';
+        }
+
+        $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT', $working);
+        if (false === $transliterated || '' === $transliterated) {
+            $transliterated = $working;
+        }
+
+        $transliterated = trim($transliterated);
+        if ('' === $transliterated) {
+            return '#';
+        }
+
+        $first = strtoupper(substr($transliterated, 0, 1));
+        $first = apply_filters('ap_letter_map', $first, $title, $locale);
+
+        return preg_match('/^[A-Z]$/', $first) ? $first : '#';
+    }
+
+    /**
+     * Ensure the normalised letter meta for a post is up to date.
+     */
+    public static function update_post_letter(int $post_id, string $title = '', string $locale = ''): string
+    {
+        $title = $title ?: get_the_title($post_id);
+        $letter = self::normalizeLetter($title, $locale);
+
+        $current = get_post_meta($post_id, self::META_KEY, true);
+        if ($current !== $letter) {
+            update_post_meta($post_id, self::META_KEY, $letter);
+        }
+
+        return $letter;
+    }
+
+    /**
+     * Backfill missing letter metadata for a post type.
+     */
+    public static function backfill_missing_letters(string $post_type, int $limit = 50): void
+    {
+        global $wpdb;
+
+        $post_type = sanitize_key($post_type);
+        if ('' === $post_type) {
+            return;
+        }
+
+        $ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT p.ID FROM {$wpdb->posts} AS p
+             LEFT JOIN {$wpdb->postmeta} AS m ON (p.ID = m.post_id AND m.meta_key = %s)
+             WHERE p.post_type = %s AND p.post_status = 'publish' AND m.post_id IS NULL
+             LIMIT %d",
+            self::META_KEY,
+            $post_type,
+            $limit
+        ));
+
+        if (empty($ids)) {
+            return;
+        }
+
+        foreach ($ids as $post_id) {
+            $post = get_post((int) $post_id);
+            if ($post && $post->post_type === $post_type) {
+                self::update_post_letter((int) $post->ID, $post->post_title);
+            }
+        }
+    }
+
+    /**
+     * Callback hooked to save_post to refresh the cached letter.
+     */
+    public static function update_post_letter_on_save(int $post_id, \WP_Post $post, bool $update): void
+    {
+        if (wp_is_post_revision($post_id) || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
+            return;
+        }
+
+        if (!in_array($post->post_type, ['artpulse_artist', 'artpulse_org'], true)) {
+            return;
+        }
+
+        self::update_post_letter($post_id, $post->post_title);
+    }
+}

--- a/src/Frontend/ArtistsDirectory.php
+++ b/src/Frontend/ArtistsDirectory.php
@@ -1,324 +1,587 @@
 <?php
-
 namespace ArtPulse\Frontend;
+
+use ArtPulse\Core\Rewrites;
+use ArtPulse\Core\TitleTools;
+use WP_Post;
+use WP_Query;
 
 class ArtistsDirectory
 {
     private const SHORTCODE = 'ap_artists_directory';
-    private const STYLE_HANDLE = 'ap-artists-directory';
-    private const SCRIPT_HANDLE = 'ap-artists-directory';
-    private const TRANSIENT_PREFIX = 'ap_artists_directory_';
-    private const CACHE_KEYS_OPTION = 'ap_artists_directory_cache_keys';
+    private const POST_TYPE = 'artpulse_artist';
+    private const CACHE_OPTION = 'ap_directory_cache_versions';
+    private const CACHE_TTL = 6 * HOUR_IN_SECONDS;
+
+    private static ?string $canonical_url = null;
 
     public static function register(): void
     {
         add_shortcode(self::SHORTCODE, [self::class, 'render_shortcode']);
-        add_action('init', [self::class, 'register_assets']);
-        add_action('wp_enqueue_scripts', [self::class, 'maybe_enqueue_assets']);
-
-        add_action('save_post_artpulse_artist', [self::class, 'clear_cache'], 10, 0);
-        add_action('trashed_post', [self::class, 'maybe_clear_cache']);
-        add_action('deleted_post', [self::class, 'maybe_clear_cache']);
-    }
-
-    public static function register_assets(): void
-    {
-        $plugin_url = plugins_url('/', ARTPULSE_PLUGIN_FILE);
-
-        wp_register_style(
-            self::STYLE_HANDLE,
-            $plugin_url . 'assets/css/ap-artists-directory.css',
-            [],
-            ARTPULSE_VERSION
-        );
-
-        wp_register_script(
-            self::SCRIPT_HANDLE,
-            $plugin_url . 'assets/js/ap-artists-directory.js',
-            [],
-            ARTPULSE_VERSION,
-            true
-        );
-    }
-
-    public static function maybe_enqueue_assets(): void
-    {
-        if (!is_singular()) {
-            return;
-        }
-
-        $post_id = get_queried_object_id();
-        if ($post_id && self::post_has_shortcode($post_id)) {
-            wp_enqueue_style(self::STYLE_HANDLE);
-            wp_enqueue_script(self::SCRIPT_HANDLE);
-        }
+        add_action('save_post_' . self::POST_TYPE, [self::class, 'flush_cache_on_save'], 10, 3);
+        add_action('transition_post_status', [self::class, 'flush_cache_on_status'], 10, 3);
+        add_action('set_object_terms', [self::class, 'flush_cache_on_terms'], 10, 6);
+        add_action('updated_post_meta', [self::class, 'flush_cache_on_meta'], 10, 4);
+        add_action('deleted_post_meta', [self::class, 'flush_cache_on_meta'], 10, 4);
+        add_action('wp_head', [self::class, 'output_canonical'], 1);
     }
 
     public static function render_shortcode(array $atts = []): string
     {
-        self::ensure_assets_enqueued();
+        TitleTools::backfill_missing_letters(self::POST_TYPE);
 
-        $atts = shortcode_atts(
-            [
-                'orderby' => 'title',
-                'order' => 'ASC',
-                'posts_per_page' => -1,
-                'letter' => '',
-            ],
-            $atts,
-            self::SHORTCODE
-        );
+        $state = self::parse_state($atts);
+        self::set_canonical_url($state);
 
-        $requested_letter = strtoupper($atts['letter'] ?: sanitize_text_field(wp_unslash($_GET['letter'] ?? '')));
-        $active_letter = $requested_letter ?: 'All';
+        $cache_key = apply_filters('ap_directory_cache_key', self::build_cache_key($state), $state, self::POST_TYPE);
+        $cached = get_transient($cache_key);
+        if (false !== $cached) {
+            return $cached;
+        }
 
-        $query_args = [
-            'post_type' => 'artpulse_artist',
-            'post_status' => 'publish',
-            'orderby' => sanitize_key($atts['orderby']),
-            'order' => strtoupper($atts['order']) === 'DESC' ? 'DESC' : 'ASC',
-            'posts_per_page' => (int) $atts['posts_per_page'],
-            'fields' => 'ids',
+        $query = new WP_Query(self::build_query_args($state));
+        $post_ids = wp_list_pluck($query->posts, 'ID');
+        if (!empty($post_ids)) {
+            update_postmeta_cache($post_ids);
+            update_object_term_cache($post_ids, [self::POST_TYPE]);
+        }
+
+        $html = self::render_directory($state, $query);
+        set_transient($cache_key, $html, self::CACHE_TTL);
+
+        return $html;
+    }
+
+    public static function output_canonical(): void
+    {
+        if (empty(self::$canonical_url)) {
+            return;
+        }
+
+        echo '<link rel="canonical" href="' . esc_url(self::$canonical_url) . '" />' . "\n";
+        self::$canonical_url = null;
+    }
+
+    private static function parse_state(array $atts): array
+    {
+        $atts = shortcode_atts([
+            'per_page' => 24,
+            'letter'   => '',
+        ], $atts, self::SHORTCODE);
+
+        $per_page = max(1, (int) $atts['per_page']);
+
+        $requested_letter = get_query_var('letter');
+        if ('' === $requested_letter && isset($_GET['letter'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $requested_letter = sanitize_text_field(wp_unslash((string) $_GET['letter']));
+        }
+        if ('' === $requested_letter && !empty($atts['letter'])) {
+            $requested_letter = (string) $atts['letter'];
+        }
+
+        $search = get_query_var('s');
+        if ('' === $search && isset($_GET['s'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $search = sanitize_text_field(wp_unslash((string) $_GET['s']));
+        }
+
+        $tax_filters = self::parse_tax_filters();
+
+        $paged = (int) get_query_var('paged');
+        if ($paged < 1 && isset($_GET['paged'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $paged = (int) $_GET['paged'];
+        }
+        if ($paged < 1 && isset($_GET['page'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $paged = (int) $_GET['page'];
+        }
+        if ($paged < 1) {
+            $paged = 1;
+        }
+
+        return [
+            'letter'       => self::normalize_letter($requested_letter),
+            'search'       => is_string($search) ? $search : '',
+            'tax_filters'  => $tax_filters,
+            'paged'        => $paged,
+            'per_page'     => $per_page,
+        ];
+    }
+
+    private static function build_query_args(array $state): array
+    {
+        $args = [
+            'post_type'      => self::POST_TYPE,
+            'post_status'    => 'publish',
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+            'posts_per_page' => $state['per_page'],
+            'paged'          => $state['paged'],
         ];
 
-        $query_args = apply_filters('artpulse_artists_directory_args', $query_args, $atts);
+        if ($state['search'] !== '') {
+            $args['s'] = $state['search'];
+        }
 
-        $cache_key = self::get_cache_key($query_args);
-        $artists = get_transient($cache_key);
-
-        if (false === $artists) {
-            $artist_posts = get_posts($query_args);
-            $artists = [];
-
-            foreach ($artist_posts as $post_id) {
-                $post = get_post($post_id);
-                if (!$post instanceof \WP_Post) {
-                    continue;
-                }
-
-                $organization = get_post_meta($post->ID, '_ap_artist_org', true);
-                $role = get_post_meta($post->ID, '_ap_artist_role', true);
-                $location = get_post_meta($post->ID, '_ap_artist_location', true);
-
-                $fields = [
-                    'thumbnail' => get_the_post_thumbnail($post->ID, 'medium'),
-                    'name' => sprintf(
-                        '<a href="%s">%s</a>',
-                        esc_url(get_permalink($post)),
-                        esc_html(get_the_title($post))
-                    ),
-                    'organization' => is_scalar($organization) ? sanitize_text_field((string) $organization) : $organization,
-                    'role' => is_scalar($role) ? sanitize_text_field((string) $role) : $role,
-                    'location' => is_scalar($location) ? sanitize_text_field((string) $location) : $location,
-                ];
-
-                $fields = apply_filters('artpulse_artists_directory_fields', $fields, $post);
-
-                $artists[] = [
-                    'id' => $post->ID,
-                    'title' => get_the_title($post),
-                    'fields' => $fields,
+        if (!empty($state['tax_filters'])) {
+            $tax_query = [];
+            foreach ($state['tax_filters'] as $taxonomy => $terms) {
+                $tax_query[] = [
+                    'taxonomy' => $taxonomy,
+                    'field'    => 'slug',
+                    'terms'    => $terms,
                 ];
             }
-
-            set_transient($cache_key, $artists, 12 * HOUR_IN_SECONDS);
-            self::remember_cache_key($cache_key);
+            if (!empty($tax_query)) {
+                $args['tax_query'] = $tax_query;
+            }
         }
 
-        if (empty($artists)) {
-            return '<p class="ap-artists-directory-empty">' . esc_html__('No artists found at this time.', 'artpulse') . '</p>';
+        if ('all' !== $state['letter']) {
+            $args['meta_query'] = [
+                [
+                    'key'     => TitleTools::META_KEY,
+                    'value'   => $state['letter'],
+                    'compare' => '=',
+                ],
+            ];
         }
 
-        $groups = self::group_artists_by_letter($artists);
-        $letters = array_merge(['All'], range('A', 'Z'), ['#']);
-        $active_letter = in_array($active_letter, $letters, true) ? $active_letter : 'All';
+        return $args;
+    }
 
-        $has_results_for_active = 'All' === $active_letter
-            ? !empty($artists)
-            : !empty($groups[$active_letter] ?? []);
+    private static function render_directory(array $state, WP_Query $query): string
+    {
+        $letters = self::get_letters();
+        $heading = self::get_heading_label($state['letter']);
+        $results_total = (int) $query->found_posts;
+        $summary = self::format_summary($results_total);
 
         ob_start();
         ?>
-        <div class="ap-artists-directory" data-active-letter="<?php echo esc_attr($active_letter); ?>" data-default-letter="<?php echo esc_attr($active_letter); ?>">
-            <nav class="ap-directory-filter" aria-label="<?php esc_attr_e('Filter artists alphabetically', 'artpulse'); ?>">
-                <ul class="ap-directory-filter__list">
-                    <?php foreach ($letters as $letter) :
-                        if ('#' === $letter && empty($groups['#'] ?? [])) {
-                            continue;
+        <div class="ap-directory" data-letter="<?php echo esc_attr($state['letter']); ?>">
+            <a class="ap-directory__skip-link" href="#ap-artists-directory-results">
+                <?php esc_html_e('Skip to results', 'artpulse-management'); ?>
+            </a>
+            <?php echo self::render_letter_nav($letters, $state); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo self::render_search_form($state); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <p class="ap-directory__announce" aria-live="polite" aria-atomic="true">
+                <?php echo esc_html($summary); ?>
+            </p>
+            <div id="ap-artists-directory-results" class="ap-directory__results" tabindex="-1">
+                <h2 class="ap-directory__heading">
+                    <?php echo esc_html($heading); ?>
+                </h2>
+                <?php
+                if (!empty($query->posts)) {
+                    echo '<ul class="ap-directory__list">';
+                    foreach ($query->posts as $post) {
+                        if ($post instanceof WP_Post) {
+                            echo self::render_item($post); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                         }
-                        $is_active = $letter === $active_letter;
-                        $url = 'All' === $letter
-                            ? esc_url(remove_query_arg('letter'))
-                            : esc_url(add_query_arg('letter', $letter));
-                        ?>
-                        <li class="ap-directory-filter__item">
-                            <a
-                                href="<?php echo $url; ?>"
-                                class="ap-directory-filter__control<?php echo $is_active ? ' is-active' : ''; ?>"
-                                role="button"
-                                data-letter="<?php echo esc_attr($letter); ?>"
-                                aria-pressed="<?php echo $is_active ? 'true' : 'false'; ?>"
-                            >
-                                <?php echo 'All' === $letter ? esc_html__('All', 'artpulse') : esc_html($letter); ?>
-                            </a>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
-            </nav>
-            <div class="ap-directory-results" aria-live="polite" aria-busy="false">
-                <?php foreach ($groups as $letter => $items) :
-                    $is_visible = 'All' === $active_letter || $letter === $active_letter;
-                    $hidden_attr = $is_visible ? '' : ' hidden';
-                    ?>
-                    <section class="ap-directory-section" data-letter="<?php echo esc_attr($letter); ?>"<?php echo $hidden_attr; ?>>
-                        <h2 class="ap-directory-heading">
-                            <?php echo 'All' === $letter ? esc_html__('All Artists', 'artpulse') : esc_html($letter); ?>
-                        </h2>
-                        <div class="ap-directory-grid">
-                            <?php foreach ($items as $artist) :
-                                $fields = $artist['fields'];
-                                ?>
-                                <article class="ap-artist-card">
-                                    <?php if (!empty($fields['thumbnail'])) : ?>
-                                        <div class="ap-artist-card__thumb">
-                                            <?php echo wp_kses_post($fields['thumbnail']); ?>
-                                        </div>
-                                    <?php endif; ?>
-                                    <div class="ap-artist-card__body">
-                                        <h3 class="ap-artist-card__title">
-                                            <?php echo isset($fields['name']) ? wp_kses_post($fields['name']) : esc_html($artist['title']); ?>
-                                        </h3>
-                                        <?php if (!empty($fields['organization']) || !empty($fields['role']) || !empty($fields['location'])) : ?>
-                                            <ul class="ap-artist-card__meta">
-                                                <?php if (!empty($fields['organization'])) : ?>
-                                                    <li class="ap-artist-card__meta-item ap-artist-card__meta-item--organization">
-                                                        <?php echo wp_kses_post(is_array($fields['organization']) ? implode(' ', $fields['organization']) : $fields['organization']); ?>
-                                                    </li>
-                                                <?php endif; ?>
-                                                <?php if (!empty($fields['role'])) : ?>
-                                                    <li class="ap-artist-card__meta-item ap-artist-card__meta-item--role">
-                                                        <?php echo wp_kses_post(is_array($fields['role']) ? implode(' ', $fields['role']) : $fields['role']); ?>
-                                                    </li>
-                                                <?php endif; ?>
-                                                <?php if (!empty($fields['location'])) : ?>
-                                                    <li class="ap-artist-card__meta-item ap-artist-card__meta-item--location">
-                                                        <?php echo wp_kses_post(is_array($fields['location']) ? implode(' ', $fields['location']) : $fields['location']); ?>
-                                                    </li>
-                                                <?php endif; ?>
-                                            </ul>
-                                        <?php endif; ?>
-                                    </div>
-                                </article>
-                            <?php endforeach; ?>
-                        </div>
-                    </section>
-                <?php endforeach; ?>
-                <p class="ap-directory-empty"<?php echo $has_results_for_active ? ' hidden' : ''; ?>><?php esc_html_e('No artists match the selected letter.', 'artpulse'); ?></p>
+                    }
+                    echo '</ul>';
+                } else {
+                    echo '<p class="ap-directory__empty">' . esc_html__('No artists found for this selection.', 'artpulse-management') . '</p>';
+                }
+                ?>
             </div>
+            <?php echo self::render_pagination($state, $query); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         </div>
         <?php
-        return trim((string) ob_get_clean());
+        wp_reset_postdata();
+
+        return ob_get_clean();
     }
 
-    public static function clear_cache(?int $post_id = null): void
+    private static function render_item(WP_Post $post): string
     {
-        $keys = get_option(self::CACHE_KEYS_OPTION, []);
-        if (!is_array($keys)) {
-            $keys = [];
-        }
+        $data = [
+            'thumbnail' => get_the_post_thumbnail($post->ID, 'medium_large', ['loading' => 'lazy']),
+            'permalink' => get_permalink($post),
+            'title'     => get_the_title($post),
+            'excerpt'   => self::get_excerpt($post),
+            'meta'      => self::get_item_meta($post),
+        ];
 
-        foreach ($keys as $key) {
-            delete_transient($key);
-        }
+        $data = apply_filters('ap_directory_item_data', $data, $post, self::POST_TYPE);
 
-        update_option(self::CACHE_KEYS_OPTION, []);
+        $template = self::locate_template();
+
+        $item_post = $post; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+        $item_data = $data; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+        $post_type = self::POST_TYPE; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+        ob_start();
+        include $template;
+
+        return ob_get_clean();
     }
 
-    public static function maybe_clear_cache(int $post_id): void
+    private static function get_excerpt(WP_Post $post): string
     {
-        if ('artpulse_artist' === get_post_type($post_id)) {
-            self::clear_cache();
+        $excerpt = get_the_excerpt($post);
+        if (!is_string($excerpt) || $excerpt === '') {
+            $content = get_post_field('post_content', $post->ID);
+            $excerpt = is_string($content) ? wp_strip_all_tags($content) : '';
         }
+
+        return wp_trim_words($excerpt, 35, '…');
     }
 
-    private static function ensure_assets_enqueued(): void
+    private static function get_item_meta(WP_Post $post): array
     {
-        if (!wp_style_is(self::STYLE_HANDLE, 'enqueued')) {
-            wp_enqueue_style(self::STYLE_HANDLE);
+        $meta = [];
+
+        $org = get_post_meta($post->ID, '_ap_artist_org', true);
+        if (is_numeric($org)) {
+            $title = get_the_title((int) $org);
+            if (is_string($title) && $title !== '') {
+                $meta[] = $title;
+            }
+        } elseif (is_string($org) && $org !== '') {
+            $meta[] = wp_strip_all_tags($org);
         }
-        if (!wp_script_is(self::SCRIPT_HANDLE, 'enqueued')) {
-            wp_enqueue_script(self::SCRIPT_HANDLE);
+
+        $role = get_post_meta($post->ID, '_ap_artist_role', true);
+        if (is_string($role) && $role !== '') {
+            $meta[] = wp_strip_all_tags($role);
         }
+
+        $location = get_post_meta($post->ID, '_ap_artist_location', true);
+        if (is_string($location) && $location !== '') {
+            $meta[] = wp_strip_all_tags($location);
+        }
+
+        $specialties = get_the_terms($post, 'artist_specialty');
+        if (is_array($specialties) && !empty($specialties)) {
+            $names = array_filter(array_map(static function ($term) {
+                return isset($term->name) ? wp_strip_all_tags($term->name) : '';
+            }, $specialties));
+            if (!empty($names)) {
+                $meta[] = implode(', ', $names);
+            }
+        }
+
+        $meta = array_values(array_filter($meta, static function ($value) {
+            return is_string($value) && $value !== '';
+        }));
+
+        return apply_filters('ap_artists_directory_meta', $meta, $post);
     }
 
-    /**
-     * @param array<string, mixed> $query_args
-     */
-    private static function get_cache_key(array $query_args): string
+    private static function render_letter_nav(array $letters, array $state): string
     {
-        return self::TRANSIENT_PREFIX . md5(wp_json_encode($query_args));
-    }
-
-    private static function remember_cache_key(string $cache_key): void
-    {
-        $keys = get_option(self::CACHE_KEYS_OPTION, []);
-        if (!is_array($keys)) {
-            $keys = [];
-        }
-
-        if (!in_array($cache_key, $keys, true)) {
-            $keys[] = $cache_key;
-            update_option(self::CACHE_KEYS_OPTION, $keys);
-        }
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $artists
-     * @return array<string, array<int, array<string, mixed>>>
-     */
-    private static function group_artists_by_letter(array $artists): array
-    {
-        $groups = ['All' => []];
-
-        foreach ($artists as $artist) {
-            $title = $artist['title'];
-            $first_character = function_exists('mb_substr')
-                ? mb_substr($title, 0, 1)
-                : substr($title, 0, 1);
-            $first_letter = strtoupper((string) $first_character);
-            if (!preg_match('/[A-Z]/', $first_letter)) {
-                $first_letter = '#';
+        $items = [];
+        foreach ($letters as $letter) {
+            $is_active = $letter === $state['letter'];
+            $url = self::build_letter_url($letter, $state);
+            $classes = ['ap-directory__letter-link'];
+            if ($is_active) {
+                $classes[] = 'is-active';
             }
 
-            if (!isset($groups[$first_letter])) {
-                $groups[$first_letter] = [];
-            }
-
-            $groups['All'][] = $artist;
-            $groups[$first_letter][] = $artist;
+            $items[] = sprintf(
+                '<li class="ap-directory__letter-item"><a class="%s" href="%s"%s>%s</a></li>',
+                esc_attr(implode(' ', $classes)),
+                esc_url($url),
+                $is_active ? ' aria-current="page"' : '',
+                esc_html(self::format_letter_label($letter))
+            );
         }
 
-        ksort($groups);
-        if (isset($groups['All'])) {
-            $all = $groups['All'];
-            unset($groups['All']);
-            $groups = array_merge(['All' => $all], $groups);
-        }
-
-        return $groups;
+        return sprintf(
+            '<nav class="ap-directory__letters" aria-label="%s"><ul class="ap-directory__letters-list">%s</ul></nav>',
+            esc_attr__('Browse artists by letter', 'artpulse-management'),
+            implode('', $items)
+        );
     }
 
-    private static function post_has_shortcode(int $post_id): bool
+    private static function render_search_form(array $state): string
     {
-        $post = get_post($post_id);
-        if (!$post instanceof \WP_Post) {
-            return false;
+        $action = Rewrites::get_directory_letter_url('artists', $state['letter']);
+        $search_value = $state['search'];
+        $letter_value = $state['letter'];
+
+        ob_start();
+        ?>
+        <form class="ap-directory__search" role="search" method="get" action="<?php echo esc_url($action); ?>">
+            <label class="screen-reader-text" for="ap-artists-directory-search">
+                <?php esc_html_e('Search artists', 'artpulse-management'); ?>
+            </label>
+            <input
+                type="search"
+                id="ap-artists-directory-search"
+                name="s"
+                value="<?php echo esc_attr($search_value); ?>"
+                placeholder="<?php echo esc_attr__('Search artists', 'artpulse-management'); ?>"
+            />
+            <input type="hidden" name="letter" value="<?php echo esc_attr($letter_value); ?>" />
+            <?php foreach ($state['tax_filters'] as $taxonomy => $terms) :
+                foreach ($terms as $term) : ?>
+                    <input type="hidden" name="tax[<?php echo esc_attr($taxonomy); ?>][]" value="<?php echo esc_attr($term); ?>" />
+                <?php endforeach;
+            endforeach; ?>
+            <button type="submit">
+                <?php esc_html_e('Search', 'artpulse-management'); ?>
+            </button>
+        </form>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    private static function render_pagination(array $state, WP_Query $query): string
+    {
+        if ($query->max_num_pages <= 1) {
+            return '';
         }
 
-        if (has_shortcode($post->post_content, self::SHORTCODE)) {
-            return true;
+        $base_url = Rewrites::get_directory_letter_url('artists', $state['letter'], self::build_canonical_query_args($state, false));
+        $base_url = remove_query_arg('paged', $base_url);
+
+        $links = paginate_links([
+            'base'      => add_query_arg('paged', '%#%', $base_url),
+            'format'    => '',
+            'current'   => max(1, (int) $state['paged']),
+            'total'     => (int) $query->max_num_pages,
+            'prev_text' => esc_html__('Previous', 'artpulse-management'),
+            'next_text' => esc_html__('Next', 'artpulse-management'),
+            'type'      => 'array',
+        ]);
+
+        if (empty($links)) {
+            return '';
         }
 
-        return false;
+        $items = array_map(static function ($link) {
+            return '<li class="ap-directory__pagination-item">' . $link . '</li>';
+        }, $links);
+
+        return sprintf(
+            '<nav class="ap-directory__pagination" aria-label="%s"><ul class="ap-directory__pagination-list">%s</ul></nav>',
+            esc_attr__('Artists pagination', 'artpulse-management'),
+            implode('', $items)
+        );
+    }
+
+    private static function get_letters(): array
+    {
+        return array_merge(['all'], range('A', 'Z'), ['#']);
+    }
+
+    private static function normalize_letter(string $letter): string
+    {
+        $letter = trim(rawurldecode($letter));
+        if ('' === $letter) {
+            return 'A';
+        }
+
+        if (strtolower($letter) === 'all') {
+            return 'all';
+        }
+
+        if ('#' === $letter) {
+            return '#';
+        }
+
+        $first = strtoupper(substr($letter, 0, 1));
+        if (preg_match('/^[A-Z]$/', $first)) {
+            return $first;
+        }
+
+        return '#';
+    }
+
+    private static function format_letter_label(string $letter): string
+    {
+        if ('all' === $letter) {
+            return __('All', 'artpulse-management');
+        }
+
+        return $letter;
+    }
+
+    private static function get_heading_label(string $letter): string
+    {
+        if ('all' === $letter) {
+            return __('All Artists', 'artpulse-management');
+        }
+
+        if ('#' === $letter) {
+            return __('Artists starting with #', 'artpulse-management');
+        }
+
+        return sprintf(
+            /* translators: %s is the active letter. */
+            __('Artists starting with %s', 'artpulse-management'),
+            $letter
+        );
+    }
+
+    private static function format_summary(int $total): string
+    {
+        return sprintf(
+            /* translators: %s is the number of artists. */
+            _n('%s artist found', '%s artists found', $total, 'artpulse-management'),
+            number_format_i18n($total)
+        );
+    }
+
+    private static function build_letter_url(string $letter, array $state): string
+    {
+        $query = self::build_canonical_query_args($state, false);
+        $query['letter'] = $letter;
+        unset($query['paged']);
+
+        return Rewrites::get_directory_letter_url('artists', $letter, $query);
+    }
+
+    private static function build_canonical_query_args(array $state, bool $include_paged = true): array
+    {
+        $query = [];
+        if ($state['search'] !== '') {
+            $query['s'] = $state['search'];
+        }
+
+        if (!empty($state['tax_filters'])) {
+            $query['tax'] = $state['tax_filters'];
+        }
+
+        if ($include_paged && $state['paged'] > 1) {
+            $query['paged'] = $state['paged'];
+        }
+
+        return $query;
+    }
+
+    private static function set_canonical_url(array $state): void
+    {
+        $url = Rewrites::get_directory_letter_url('artists', $state['letter'], self::build_canonical_query_args($state));
+        self::$canonical_url = esc_url_raw($url);
+    }
+
+    private static function build_cache_key(array $state): string
+    {
+        $version = self::get_cache_version();
+        $search_hash = $state['search'] !== '' ? md5($state['search']) : '0';
+        $tax_hash = !empty($state['tax_filters']) ? md5(wp_json_encode($state['tax_filters'])) : '0';
+
+        return sprintf(
+            'ap_dir:%s:v%s:letter=%s:s=%s:tax=%s:page=%d:pp=%d',
+            self::POST_TYPE,
+            $version,
+            rawurlencode($state['letter']),
+            $search_hash,
+            $tax_hash,
+            $state['paged'],
+            $state['per_page']
+        );
+    }
+
+    private static function get_cache_version(): int
+    {
+        $versions = get_option(self::CACHE_OPTION, []);
+        if (!is_array($versions)) {
+            $versions = [];
+        }
+
+        return isset($versions[self::POST_TYPE]) ? (int) $versions[self::POST_TYPE] : 1;
+    }
+
+    private static function bump_cache_version(): void
+    {
+        $versions = get_option(self::CACHE_OPTION, []);
+        if (!is_array($versions)) {
+            $versions = [];
+        }
+
+        $current = isset($versions[self::POST_TYPE]) ? (int) $versions[self::POST_TYPE] : 1;
+        $versions[self::POST_TYPE] = $current + 1;
+
+        update_option(self::CACHE_OPTION, $versions, false);
+    }
+
+    private static function flush_cache_on_save(int $post_id, WP_Post $post, bool $update): void
+    {
+        if ($post->post_type !== self::POST_TYPE) {
+            return;
+        }
+
+        self::bump_cache_version();
+    }
+
+    private static function flush_cache_on_status(string $new_status, string $old_status, WP_Post $post): void
+    {
+        if ($post->post_type !== self::POST_TYPE) {
+            return;
+        }
+
+        if ($new_status !== $old_status) {
+            self::bump_cache_version();
+        }
+    }
+
+    private static function flush_cache_on_terms(int $object_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids): void
+    {
+        if (get_post_type($object_id) !== self::POST_TYPE) {
+            return;
+        }
+
+        self::bump_cache_version();
+    }
+
+    private static function flush_cache_on_meta($meta_id, int $object_id, $meta_key = '', $meta_value = ''): void
+    {
+        if (get_post_type($object_id) !== self::POST_TYPE) {
+            return;
+        }
+
+        self::bump_cache_version();
+    }
+
+    private static function parse_tax_filters(): array
+    {
+        $filters = [];
+        if (!isset($_GET['tax'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return $filters;
+        }
+
+        $raw = wp_unslash($_GET['tax']); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if (!is_array($raw)) {
+            return $filters;
+        }
+
+        foreach ($raw as $taxonomy => $terms) {
+            $taxonomy = sanitize_key($taxonomy);
+            if ('' === $taxonomy) {
+                continue;
+            }
+
+            $terms = is_array($terms) ? $terms : explode(',', (string) $terms);
+            $terms = array_filter(array_map(static function ($term) {
+                $term = is_string($term) ? sanitize_title($term) : '';
+                return $term;
+            }, $terms));
+
+            if (!empty($terms)) {
+                $filters[$taxonomy] = array_values($terms);
+            }
+        }
+
+        return $filters;
+    }
+
+    private static function locate_template(): string
+    {
+        $candidates = [
+            'artpulse/directory-item-' . self::POST_TYPE . '.php',
+            'artpulse/directory-item.php',
+        ];
+
+        $template = locate_template($candidates);
+        if (!is_string($template) || '' === $template) {
+            $template = plugin_dir_path(ARTPULSE_PLUGIN_FILE) . 'templates/partials/directory-item.php';
+        }
+
+        return $template;
     }
 }

--- a/src/Frontend/OrgsDirectory.php
+++ b/src/Frontend/OrgsDirectory.php
@@ -1,676 +1,578 @@
 <?php
-
 namespace ArtPulse\Frontend;
 
-use ArtPulse\Community\FavoritesManager;
-use WP_Query;
+use ArtPulse\Core\Rewrites;
+use ArtPulse\Core\TitleTools;
 use WP_Post;
+use WP_Query;
 
 class OrgsDirectory
 {
-    private const TRANSIENT_PREFIX = 'ap_orgs_dir_';
-    private const TRANSIENT_ALL_PREFIX = 'ap_orgs_dir_all_';
+    private const SHORTCODE = 'ap_orgs_directory';
+    private const POST_TYPE = 'artpulse_org';
+    private const CACHE_OPTION = 'ap_directory_cache_versions';
+    private const CACHE_TTL = 6 * HOUR_IN_SECONDS;
+
+    private static ?string $canonical_url = null;
 
     public static function register(): void
     {
-        add_shortcode('ap_orgs_directory', [self::class, 'render_shortcode']);
-        add_action('init', [self::class, 'register_cache_busters']);
-        add_action('wp_enqueue_scripts', [self::class, 'register_assets']);
+        add_shortcode(self::SHORTCODE, [self::class, 'render_shortcode']);
+        add_action('save_post_' . self::POST_TYPE, [self::class, 'flush_cache_on_save'], 10, 3);
+        add_action('transition_post_status', [self::class, 'flush_cache_on_status'], 10, 3);
+        add_action('set_object_terms', [self::class, 'flush_cache_on_terms'], 10, 6);
+        add_action('updated_post_meta', [self::class, 'flush_cache_on_meta'], 10, 4);
+        add_action('deleted_post_meta', [self::class, 'flush_cache_on_meta'], 10, 4);
+        add_action('wp_head', [self::class, 'output_canonical'], 1);
     }
 
-    public static function register_assets(): void
+    public static function render_shortcode(array $atts = []): string
     {
-        if (!wp_style_is('ap-orgs-directory', 'registered')) {
-            wp_register_style(
-                'ap-orgs-directory',
-                plugins_url('assets/css/ap-orgs-directory.css', ARTPULSE_PLUGIN_FILE),
-                [],
-                defined('ARTPULSE_VERSION') ? ARTPULSE_VERSION : null
-            );
+        TitleTools::backfill_missing_letters(self::POST_TYPE);
+
+        $state = self::parse_state($atts);
+        self::set_canonical_url($state);
+
+        $cache_key = apply_filters('ap_directory_cache_key', self::build_cache_key($state), $state, self::POST_TYPE);
+        $cached = get_transient($cache_key);
+        if (false !== $cached) {
+            return $cached;
         }
 
-        if (!wp_script_is('ap-orgs-directory', 'registered')) {
-            wp_register_script(
-                'ap-orgs-directory',
-                plugins_url('assets/js/ap-orgs-directory.js', ARTPULSE_PLUGIN_FILE),
-                [],
-                defined('ARTPULSE_VERSION') ? ARTPULSE_VERSION : null,
-                true
-            );
+        $query = new WP_Query(self::build_query_args($state));
+        $post_ids = wp_list_pluck($query->posts, 'ID');
+        if (!empty($post_ids)) {
+            update_postmeta_cache($post_ids);
+            update_object_term_cache($post_ids, [self::POST_TYPE]);
         }
+
+        $html = self::render_directory($state, $query);
+        set_transient($cache_key, $html, self::CACHE_TTL);
+
+        return $html;
     }
 
-    public static function register_cache_busters(): void
+    public static function output_canonical(): void
     {
-        $post_type = self::get_post_type_slug();
+        if (empty(self::$canonical_url)) {
+            return;
+        }
 
-        add_action('save_post_' . $post_type, [self::class, 'flush_cache']);
-        add_action('deleted_post', [self::class, 'maybe_flush_on_delete']);
+        echo '<link rel="canonical" href="' . esc_url(self::$canonical_url) . '" />' . "\n";
+        self::$canonical_url = null;
     }
 
-    public static function flush_cache(): void
+    private static function parse_state(array $atts): array
     {
-        global $wpdb;
+        $atts = shortcode_atts([
+            'per_page' => 24,
+            'letter'   => '',
+        ], $atts, self::SHORTCODE);
 
-        $like_patterns = [
-            '_transient_' . self::TRANSIENT_PREFIX . '%',
-            '_transient_timeout_' . self::TRANSIENT_PREFIX . '%',
-            '_transient_' . self::TRANSIENT_ALL_PREFIX . '%',
-            '_transient_timeout_' . self::TRANSIENT_ALL_PREFIX . '%',
+        $per_page = max(1, (int) $atts['per_page']);
+
+        $requested_letter = get_query_var('letter');
+        if ('' === $requested_letter && isset($_GET['letter'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $requested_letter = sanitize_text_field(wp_unslash((string) $_GET['letter']));
+        }
+        if ('' === $requested_letter && !empty($atts['letter'])) {
+            $requested_letter = (string) $atts['letter'];
+        }
+
+        $search = get_query_var('s');
+        if ('' === $search && isset($_GET['s'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $search = sanitize_text_field(wp_unslash((string) $_GET['s']));
+        }
+
+        $tax_filters = self::parse_tax_filters();
+
+        $paged = (int) get_query_var('paged');
+        if ($paged < 1 && isset($_GET['paged'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $paged = (int) $_GET['paged'];
+        }
+        if ($paged < 1 && isset($_GET['page'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $paged = (int) $_GET['page'];
+        }
+        if ($paged < 1) {
+            $paged = 1;
+        }
+
+        return [
+            'letter'      => self::normalize_letter($requested_letter),
+            'search'      => is_string($search) ? $search : '',
+            'tax_filters' => $tax_filters,
+            'paged'       => $paged,
+            'per_page'    => $per_page,
+        ];
+    }
+
+    private static function build_query_args(array $state): array
+    {
+        $args = [
+            'post_type'      => self::POST_TYPE,
+            'post_status'    => 'publish',
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+            'posts_per_page' => $state['per_page'],
+            'paged'          => $state['paged'],
         ];
 
-        foreach ($like_patterns as $pattern) {
-            $wpdb->query(
-                $wpdb->prepare(
-                    "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-                    $pattern
-                )
-            );
-        }
-    }
-
-    public static function maybe_flush_on_delete(int $post_id): void
-    {
-        $post = get_post($post_id);
-        if ($post instanceof WP_Post && $post->post_type === self::get_post_type_slug()) {
-            self::flush_cache();
-        }
-    }
-
-    public static function render_shortcode($atts = []): string
-    {
-        if (!post_type_exists(self::get_post_type_slug())) {
-            return '';
+        if ($state['search'] !== '') {
+            $args['s'] = $state['search'];
         }
 
-        $atts = shortcode_atts([
-            'letters'        => 'A-Z|All',
-            'per_page'       => 24,
-            'taxonomy'       => '',
-            'show_search'    => 'true',
-            'show_favorites' => 'true',
-        ], $atts, 'ap_orgs_directory');
-
-        $letters = apply_filters('artpulse_orgs_directory_letters', self::parse_letters($atts['letters']));
-
-        $per_page = (int) $atts['per_page'];
-        if ($per_page <= 0) {
-            $per_page = 24;
-        }
-
-        $taxonomy_filter = self::parse_taxonomy_attribute($atts['taxonomy']);
-
-        $show_search = self::is_truthy($atts['show_search']);
-        $show_favorites = self::is_truthy($atts['show_favorites']);
-
-        $active_letter = isset($_GET['letter']) ? sanitize_text_field(wp_unslash($_GET['letter'])) : '';
-        $active_letter = self::normalize_letter_query($active_letter, $letters);
-
-        $search_term = isset($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : '';
-
-        $page = isset($_GET['page']) ? max(1, (int) $_GET['page']) : 1;
-
-        $post_type = self::get_post_type_slug();
-
-        $all_items = self::get_all_items($post_type, $taxonomy_filter, $search_term);
-
-        $pagination = self::get_paginated_ids(
-            $all_items,
-            $active_letter,
-            $per_page,
-            $page,
-            $taxonomy_filter,
-            $search_term
-        );
-
-        $favorites_lookup = [];
-        if ($show_favorites && function_exists('is_user_logged_in') && is_user_logged_in() && class_exists(FavoritesManager::class)) {
-            $user_favorites = FavoritesManager::get_user_favorites(get_current_user_id(), $post_type);
-            foreach ($user_favorites as $favorite) {
-                if ((int) $favorite->object_id > 0) {
-                    $favorites_lookup[(int) $favorite->object_id] = true;
-                }
+        if (!empty($state['tax_filters'])) {
+            $tax_query = [];
+            foreach ($state['tax_filters'] as $taxonomy => $terms) {
+                $tax_query[] = [
+                    'taxonomy' => $taxonomy,
+                    'field'    => 'slug',
+                    'terms'    => $terms,
+                ];
+            }
+            if (!empty($tax_query)) {
+                $args['tax_query'] = $tax_query;
             }
         }
 
-        $cards_by_id = [];
-        foreach ($all_items as $item) {
-            $item_id = (int) $item['id'];
-            $item['is_favorited'] = isset($favorites_lookup[$item_id]);
-            $cards_by_id[$item_id] = self::prepare_card_markup($item);
+        if ('all' !== $state['letter']) {
+            $args['meta_query'] = [
+                [
+                    'key'     => TitleTools::META_KEY,
+                    'value'   => $state['letter'],
+                    'compare' => '=',
+                ],
+            ];
         }
 
-        $visible_ids = $pagination['ids'];
-        $visible_markup = array_map(
-            static function ($id) use ($cards_by_id) {
-                return $cards_by_id[$id] ?? '';
-            },
-            $visible_ids
-        );
+        return $args;
+    }
 
-        wp_enqueue_style('ap-orgs-directory');
-        wp_localize_script(
-            'ap-orgs-directory',
-            'apOrgsDirectoryL10n',
-            [
-                'one'  => esc_html__('%s organization found', 'artpulse'),
-                'many' => esc_html__('%s organizations found', 'artpulse'),
-            ]
-        );
-        wp_enqueue_script('ap-orgs-directory');
+    private static function render_directory(array $state, WP_Query $query): string
+    {
+        $letters = self::get_letters();
+        $heading = self::get_heading_label($state['letter']);
+        $results_total = (int) $query->found_posts;
+        $summary = self::format_summary($results_total);
 
-        $current_url = self::get_current_url();
-        $base_url = remove_query_arg(['letter', 'page'], $current_url);
+        ob_start();
+        ?>
+        <div class="ap-directory ap-directory--orgs" data-letter="<?php echo esc_attr($state['letter']); ?>">
+            <a class="ap-directory__skip-link" href="#ap-orgs-directory-results">
+                <?php esc_html_e('Skip to results', 'artpulse-management'); ?>
+            </a>
+            <?php echo self::render_letter_nav($letters, $state); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo self::render_search_form($state); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <p class="ap-directory__announce" aria-live="polite" aria-atomic="true">
+                <?php echo esc_html($summary); ?>
+            </p>
+            <div id="ap-orgs-directory-results" class="ap-directory__results" tabindex="-1">
+                <h2 class="ap-directory__heading">
+                    <?php echo esc_html($heading); ?>
+                </h2>
+                <?php
+                if (!empty($query->posts)) {
+                    echo '<ul class="ap-directory__list">';
+                    foreach ($query->posts as $post) {
+                        if ($post instanceof WP_Post) {
+                            echo self::render_item($post); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        }
+                    }
+                    echo '</ul>';
+                } else {
+                    echo '<p class="ap-directory__empty">' . esc_html__('No galleries found for this selection.', 'artpulse-management') . '</p>';
+                }
+                ?>
+            </div>
+            <?php echo self::render_pagination($state, $query); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        </div>
+        <?php
+        wp_reset_postdata();
 
-        $total_results = (int) $pagination['total'];
-        $total_pages = (int) $pagination['total_pages'];
+        return ob_get_clean();
+    }
 
-        $json_data = [
-            'items'      => array_values(array_map(
-                static function ($item) use ($favorites_lookup) {
-                    $item_id = (int) $item['id'];
-                    $item['is_favorited'] = isset($favorites_lookup[$item_id]);
-                    $item['html'] = self::prepare_card_markup($item);
-                    return $item;
-                },
-                $all_items
-            )),
-            'activeLetter' => $active_letter,
-            'searchTerm'   => $search_term,
+    private static function render_item(WP_Post $post): string
+    {
+        $data = [
+            'thumbnail' => get_the_post_thumbnail($post->ID, 'medium_large', ['loading' => 'lazy']),
+            'permalink' => get_permalink($post),
+            'title'     => get_the_title($post),
+            'excerpt'   => self::get_excerpt($post),
+            'meta'      => self::get_item_meta($post),
         ];
 
-        $output = '<div class="ap-orgs-dir" data-per-page="' . esc_attr((string) $per_page) . '" data-total-pages="' . esc_attr((string) $total_pages) . '">';
-        $output .= self::render_alphabet_bar($letters, $active_letter, $base_url);
+        $data = apply_filters('ap_directory_item_data', $data, $post, self::POST_TYPE);
 
-        if ($show_search) {
-            $output .= self::render_search_form($search_term, $active_letter);
-        }
+        $template = self::locate_template();
 
-        $output .= '<div class="ap-orgs-dir__summary">' . sprintf(
-            /* translators: %s is number of organizations */
-            esc_html(_n('%s organization found', '%s organizations found', $total_results, 'artpulse')),
-            esc_html(number_format_i18n($total_results))
-        ) . '</div>';
+        $item_post = $post; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+        $item_data = $data; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+        $post_type = self::POST_TYPE; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
-        $output .= '<div class="ap-grid" role="region" aria-live="polite" aria-busy="false">' . implode('', $visible_markup) . '</div>';
-        $output .= '<div class="ap-orgs-dir__empty" role="note"' . ($total_results > 0 ? ' hidden' : '') . '>' . esc_html__('No organizations found.', 'artpulse') . '</div>';
+        ob_start();
+        include $template;
 
-        if ($total_pages > 1) {
-            $output .= self::render_pagination($page, $total_pages, $base_url, $active_letter, $search_term);
-        }
-
-        $output .= '<script type="application/json" class="ap-orgs-dir__data">' . wp_json_encode($json_data) . '</script>';
-        $output .= '</div>';
-
-        return $output;
+        return ob_get_clean();
     }
 
-    public static function get_normalized_letter(string $name): string
+    private static function get_excerpt(WP_Post $post): string
     {
-        $name = trim($name);
-        if ($name === '') {
-            return '#';
+        $excerpt = get_the_excerpt($post);
+        if (!is_string($excerpt) || $excerpt === '') {
+            $content = get_post_field('post_content', $post->ID);
+            $excerpt = is_string($content) ? wp_strip_all_tags($content) : '';
         }
 
-        $name = preg_replace('/^(?:the|a|an)\s+/i', '', $name) ?? $name;
-        $name = trim($name);
-
-        if ($name === '') {
-            return '#';
-        }
-
-        if (function_exists('remove_accents')) {
-            $name = remove_accents($name);
-        }
-
-        $first_char = strtoupper(substr($name, 0, 1));
-
-        if (preg_match('/[A-Z]/', $first_char)) {
-            return $first_char;
-        }
-
-        return '#';
+        return wp_trim_words($excerpt, 30, '…');
     }
 
-    private static function normalize_letter_query(string $letter, array $letters): string
+    private static function get_item_meta(WP_Post $post): array
     {
-        if ($letter === '') {
-            return in_array('All', $letters, true) ? 'All' : ($letters[0] ?? 'All');
+        $meta = [];
+
+        $address = get_post_meta($post->ID, '_ap_org_address', true);
+        if (is_string($address) && $address !== '') {
+            $meta[] = wp_strip_all_tags($address);
         }
 
-        $upper = strtoupper($letter);
-        if ('ALL' === $upper) {
-            return 'All';
+        $website = get_post_meta($post->ID, '_ap_org_website', true);
+        if (is_string($website) && $website !== '') {
+            $host = wp_parse_url($website, PHP_URL_HOST);
+            $meta[] = $host ? $host : wp_strip_all_tags($website);
+        }
+
+        $categories = get_the_terms($post, 'organization_category');
+        if (is_array($categories) && !empty($categories)) {
+            $names = array_filter(array_map(static function ($term) {
+                return isset($term->name) ? wp_strip_all_tags($term->name) : '';
+            }, $categories));
+            if (!empty($names)) {
+                $meta[] = implode(', ', $names);
+            }
+        }
+
+        $meta = array_values(array_filter($meta, static function ($value) {
+            return is_string($value) && $value !== '';
+        }));
+
+        return apply_filters('ap_orgs_directory_meta', $meta, $post);
+    }
+
+    private static function render_letter_nav(array $letters, array $state): string
+    {
+        $items = [];
+        foreach ($letters as $letter) {
+            $is_active = $letter === $state['letter'];
+            $url = self::build_letter_url($letter, $state);
+            $classes = ['ap-directory__letter-link'];
+            if ($is_active) {
+                $classes[] = 'is-active';
+            }
+
+            $items[] = sprintf(
+                '<li class="ap-directory__letter-item"><a class="%s" href="%s"%s>%s</a></li>',
+                esc_attr(implode(' ', $classes)),
+                esc_url($url),
+                $is_active ? ' aria-current="page"' : '',
+                esc_html(self::format_letter_label($letter))
+            );
+        }
+
+        return sprintf(
+            '<nav class="ap-directory__letters" aria-label="%s"><ul class="ap-directory__letters-list">%s</ul></nav>',
+            esc_attr__('Browse galleries by letter', 'artpulse-management'),
+            implode('', $items)
+        );
+    }
+
+    private static function render_search_form(array $state): string
+    {
+        $action = Rewrites::get_directory_letter_url('galleries', $state['letter']);
+        $search_value = $state['search'];
+        $letter_value = $state['letter'];
+
+        ob_start();
+        ?>
+        <form class="ap-directory__search" role="search" method="get" action="<?php echo esc_url($action); ?>">
+            <label class="screen-reader-text" for="ap-orgs-directory-search">
+                <?php esc_html_e('Search galleries', 'artpulse-management'); ?>
+            </label>
+            <input
+                type="search"
+                id="ap-orgs-directory-search"
+                name="s"
+                value="<?php echo esc_attr($search_value); ?>"
+                placeholder="<?php echo esc_attr__('Search galleries', 'artpulse-management'); ?>"
+            />
+            <input type="hidden" name="letter" value="<?php echo esc_attr($letter_value); ?>" />
+            <?php foreach ($state['tax_filters'] as $taxonomy => $terms) :
+                foreach ($terms as $term) : ?>
+                    <input type="hidden" name="tax[<?php echo esc_attr($taxonomy); ?>][]" value="<?php echo esc_attr($term); ?>" />
+                <?php endforeach;
+            endforeach; ?>
+            <button type="submit">
+                <?php esc_html_e('Search', 'artpulse-management'); ?>
+            </button>
+        </form>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    private static function render_pagination(array $state, WP_Query $query): string
+    {
+        if ($query->max_num_pages <= 1) {
+            return '';
+        }
+
+        $base_url = Rewrites::get_directory_letter_url('galleries', $state['letter'], self::build_canonical_query_args($state, false));
+        $base_url = remove_query_arg('paged', $base_url);
+
+        $links = paginate_links([
+            'base'      => add_query_arg('paged', '%#%', $base_url),
+            'format'    => '',
+            'current'   => max(1, (int) $state['paged']),
+            'total'     => (int) $query->max_num_pages,
+            'prev_text' => esc_html__('Previous', 'artpulse-management'),
+            'next_text' => esc_html__('Next', 'artpulse-management'),
+            'type'      => 'array',
+        ]);
+
+        if (empty($links)) {
+            return '';
+        }
+
+        $items = array_map(static function ($link) {
+            return '<li class="ap-directory__pagination-item">' . $link . '</li>';
+        }, $links);
+
+        return sprintf(
+            '<nav class="ap-directory__pagination" aria-label="%s"><ul class="ap-directory__pagination-list">%s</ul></nav>',
+            esc_attr__('Galleries pagination', 'artpulse-management'),
+            implode('', $items)
+        );
+    }
+
+    private static function get_letters(): array
+    {
+        return array_merge(['all'], range('A', 'Z'), ['#']);
+    }
+
+    private static function normalize_letter(string $letter): string
+    {
+        $letter = trim(rawurldecode($letter));
+        if ('' === $letter) {
+            return 'A';
+        }
+
+        if (strtolower($letter) === 'all') {
+            return 'all';
         }
 
         if ('#' === $letter) {
             return '#';
         }
 
-        foreach ($letters as $candidate) {
-            if (strtoupper($candidate) === $upper) {
-                return $candidate;
-            }
+        $first = strtoupper(substr($letter, 0, 1));
+        if (preg_match('/^[A-Z]$/', $first)) {
+            return $first;
         }
 
-        return in_array('All', $letters, true) ? 'All' : ($letters[0] ?? 'All');
+        return '#';
     }
 
-    private static function parse_letters(string $letters): array
+    private static function format_letter_label(string $letter): string
     {
-        $letters = strtoupper($letters);
-        $parts = preg_split('/[|,]/', $letters) ?: [];
-        $output = [];
-
-        foreach ($parts as $part) {
-            $part = trim($part);
-            if ($part === '') {
-                continue;
-            }
-
-            if ('A-Z' === $part) {
-                $output = array_merge($output, range('A', 'Z'));
-                continue;
-            }
-
-            if ('ALL' === $part) {
-                $output[] = 'All';
-                continue;
-            }
-
-            if ('#' === $part) {
-                $output[] = '#';
-                continue;
-            }
-
-            if (strlen($part) === 1 && ctype_alpha($part)) {
-                $output[] = strtoupper($part);
-            }
+        if ('all' === $letter) {
+            return __('All', 'artpulse-management');
         }
 
-        if (empty($output)) {
-            $output = array_merge(range('A', 'Z'), ['All']);
-        }
-
-        $output = array_values(array_unique($output));
-
-        if (!in_array('All', $output, true)) {
-            array_unshift($output, 'All');
-        }
-
-        return $output;
+        return $letter;
     }
 
-    private static function parse_taxonomy_attribute(string $taxonomy): array
+    private static function get_heading_label(string $letter): string
     {
-        $taxonomy = trim($taxonomy);
-        if ($taxonomy === '') {
-            return [];
+        if ('all' === $letter) {
+            return __('All Galleries', 'artpulse-management');
         }
 
-        $parts = array_map('trim', explode(':', $taxonomy));
-        if (count($parts) < 2) {
-            return [];
+        if ('#' === $letter) {
+            return __('Galleries starting with #', 'artpulse-management');
         }
 
-        [$tax_name, $term_value] = $parts;
-        if ($tax_name === '' || $term_value === '') {
-            return [];
-        }
-
-        return [
-            'taxonomy' => sanitize_key($tax_name),
-            'field'    => is_numeric($term_value) ? 'term_id' : 'slug',
-            'terms'    => is_numeric($term_value) ? [(int) $term_value] : [sanitize_title($term_value)],
-        ];
-    }
-
-    private static function is_truthy($value): bool
-    {
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        $value = strtolower((string) $value);
-        return !in_array($value, ['false', '0', 'no', 'off'], true);
-    }
-
-    private static function get_post_type_slug(): string
-    {
-        static $slug = null;
-
-        if (null !== $slug) {
-            return $slug;
-        }
-
-        $candidates = apply_filters('artpulse_orgs_directory_post_types', [
-            'artpulse_org',
-            'organisation',
-            'organization',
-        ]);
-
-        foreach ($candidates as $candidate) {
-            if (post_type_exists($candidate)) {
-                $slug = $candidate;
-                return $slug;
-            }
-        }
-
-        $slug = 'artpulse_org';
-        return $slug;
-    }
-
-    private static function get_all_items(string $post_type, array $taxonomy_filter, string $search_term): array
-    {
-        $cache_key = self::TRANSIENT_ALL_PREFIX . md5($post_type . '|' . self::serialize_tax_filter($taxonomy_filter) . '|' . $search_term);
-        $cached = get_transient($cache_key);
-        if (false !== $cached) {
-            return $cached;
-        }
-
-        $query_args = [
-            'post_type'      => $post_type,
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-            'orderby'        => 'title',
-            'order'          => 'ASC',
-            'fields'         => 'ids',
-            'no_found_rows'  => true,
-        ];
-
-        if ($search_term !== '') {
-            $query_args['s'] = $search_term;
-        }
-
-        if (!empty($taxonomy_filter)) {
-            $query_args['tax_query'] = [
-                [
-                    'taxonomy' => $taxonomy_filter['taxonomy'],
-                    'field'    => $taxonomy_filter['field'],
-                    'terms'    => $taxonomy_filter['terms'],
-                ],
-            ];
-        }
-
-        $query_args = apply_filters('artpulse_orgs_directory_query_args', $query_args, [
-            'taxonomy'   => $taxonomy_filter,
-            'search'     => $search_term,
-            'post_type'  => $post_type,
-        ]);
-
-        $query = new WP_Query($query_args);
-
-        $items = [];
-
-        foreach ($query->posts as $post_id) {
-            $post_id = (int) $post_id;
-            $display_name = self::get_display_name($post_id);
-            $letter = self::get_normalized_letter($display_name);
-            $permalink = get_permalink($post_id);
-            $thumbnail = get_the_post_thumbnail_url($post_id, 'medium');
-            $excerpt = self::get_excerpt($post_id);
-
-            $badges = self::get_badges($post_id, $taxonomy_filter);
-
-            $fields = [
-                'id'           => $post_id,
-                'name'         => $display_name,
-                'letter'       => $letter,
-                'permalink'    => $permalink,
-                'thumbnail'    => $thumbnail,
-                'excerpt'      => $excerpt,
-                'badges'       => $badges,
-                'search_index' => strtolower($display_name . ' ' . implode(' ', $badges) . ' ' . $excerpt),
-                'sort_key'     => strtolower($display_name),
-            ];
-
-            $fields = apply_filters('artpulse_orgs_directory_fields', $fields, $post_id);
-
-            $items[] = $fields;
-        }
-
-        usort(
-            $items,
-            static function ($a, $b) {
-                return strcmp($a['sort_key'], $b['sort_key']);
-            }
+        return sprintf(
+            /* translators: %s is the active letter. */
+            __('Galleries starting with %s', 'artpulse-management'),
+            $letter
         );
-
-        set_transient($cache_key, $items, HOUR_IN_SECONDS);
-
-        return $items;
     }
 
-    private static function get_paginated_ids(array $items, string $letter, int $per_page, int $page, array $taxonomy_filter, string $search_term): array
+    private static function format_summary(int $total): string
     {
-        $cache_key = self::TRANSIENT_PREFIX . md5(
-            $letter . '|' . self::serialize_tax_filter($taxonomy_filter) . '|' . $page . '|' . $per_page . '|' . $search_term
+        return sprintf(
+            /* translators: %s is the number of galleries. */
+            _n('%s gallery found', '%s galleries found', $total, 'artpulse-management'),
+            number_format_i18n($total)
         );
+    }
 
-        $cached = get_transient($cache_key);
-        if (false !== $cached) {
-            return $cached;
+    private static function build_letter_url(string $letter, array $state): string
+    {
+        $query = self::build_canonical_query_args($state, false);
+        $query['letter'] = $letter;
+        unset($query['paged']);
+
+        return Rewrites::get_directory_letter_url('galleries', $letter, $query);
+    }
+
+    private static function build_canonical_query_args(array $state, bool $include_paged = true): array
+    {
+        $query = [];
+        if ($state['search'] !== '') {
+            $query['s'] = $state['search'];
         }
 
-        $filtered = array_values(array_filter(
-            $items,
-            static function ($item) use ($letter) {
-                if ('All' === $letter) {
-                    return true;
-                }
-
-                return $item['letter'] === $letter;
-            }
-        ));
-
-        $total = count($filtered);
-        $total_pages = max(1, (int) ceil($total / $per_page));
-        $page = max(1, min($page, $total_pages));
-
-        $offset = ($page - 1) * $per_page;
-        $paged_items = array_slice($filtered, $offset, $per_page);
-
-        $result = [
-            'ids'         => array_map(
-                static function ($item) {
-                    return (int) $item['id'];
-                },
-                $paged_items
-            ),
-            'total'       => $total,
-            'total_pages' => $total_pages,
-        ];
-
-        set_transient($cache_key, $result, HOUR_IN_SECONDS);
-
-        return $result;
-    }
-
-    private static function render_alphabet_bar(array $letters, string $active_letter, string $base_url): string
-    {
-        $output = '<ul class="ap-az" role="list">';
-        foreach ($letters as $letter) {
-            $is_active = ($letter === $active_letter);
-            $url = add_query_arg(
-                ['letter' => 'All' === $letter ? null : $letter, 'page' => null],
-                $base_url
-            );
-            $output .= '<li>';
-            $output .= '<a class="ap-az__link' . ($is_active ? ' is-active' : '') . '" data-letter="' . esc_attr($letter) . '" href="' . esc_url($url) . '" role="button"';
-            if ($is_active) {
-                $output .= ' aria-current="true"';
-            }
-            $output .= '>' . esc_html($letter) . '</a>';
-            $output .= '</li>';
-        }
-        $output .= '</ul>';
-
-        return $output;
-    }
-
-    private static function render_search_form(string $search_term, string $active_letter): string
-    {
-        $output = '<form class="ap-orgs-dir__search" method="get" role="search">';
-        $output .= '<label class="screen-reader-text" for="ap-orgs-dir-search">' . esc_html__('Search organizations', 'artpulse') . '</label>';
-        $output .= '<input type="search" id="ap-orgs-dir-search" name="search" value="' . esc_attr($search_term) . '" placeholder="' . esc_attr__('Search organizations…', 'artpulse') . '" />';
-        $output .= '<input type="hidden" name="letter" value="' . esc_attr($active_letter) . '" />';
-        $output .= '<button type="submit" class="ap-orgs-dir__submit">' . esc_html__('Search', 'artpulse') . '</button>';
-        $output .= '</form>';
-
-        return $output;
-    }
-
-    private static function render_pagination(int $current_page, int $total_pages, string $base_url, string $active_letter, string $search_term): string
-    {
-        $output = '<nav class="ap-orgs-dir__pagination" aria-label="' . esc_attr__('Organizations pagination', 'artpulse') . '">';
-        $output .= '<ul class="ap-orgs-dir__pagination-list">';
-
-        for ($page = 1; $page <= $total_pages; $page++) {
-            $url = add_query_arg(
-                [
-                    'page'   => $page,
-                    'letter' => 'All' === $active_letter ? null : $active_letter,
-                    'search' => $search_term !== '' ? $search_term : null,
-                ],
-                $base_url
-            );
-
-            $output .= '<li>';
-            $output .= '<a class="ap-orgs-dir__page-link' . ($page === $current_page ? ' is-active' : '') . '" href="' . esc_url($url) . '"' . ($page === $current_page ? ' aria-current="true"' : '') . '>' . esc_html((string) $page) . '</a>';
-            $output .= '</li>';
+        if (!empty($state['tax_filters'])) {
+            $query['tax'] = $state['tax_filters'];
         }
 
-        $output .= '</ul>';
-        $output .= '</nav>';
-
-        return $output;
-    }
-
-    private static function get_current_url(): string
-    {
-        $request_uri = isset($_SERVER['REQUEST_URI']) ? wp_unslash((string) $_SERVER['REQUEST_URI']) : '';
-        if ($request_uri === '') {
-            return '';
+        if ($include_paged && $state['paged'] > 1) {
+            $query['paged'] = $state['paged'];
         }
 
-        $scheme = is_ssl() ? 'https' : 'http';
-        $host = isset($_SERVER['HTTP_HOST']) ? sanitize_text_field(wp_unslash((string) $_SERVER['HTTP_HOST'])) : '';
-        return esc_url_raw($scheme . '://' . $host . $request_uri);
+        return $query;
     }
 
-    private static function get_display_name(int $post_id): string
+    private static function set_canonical_url(array $state): void
+    {
+        $url = Rewrites::get_directory_letter_url('galleries', $state['letter'], self::build_canonical_query_args($state));
+        self::$canonical_url = esc_url_raw($url);
+    }
+
+    private static function build_cache_key(array $state): string
+    {
+        $version = self::get_cache_version();
+        $search_hash = $state['search'] !== '' ? md5($state['search']) : '0';
+        $tax_hash = !empty($state['tax_filters']) ? md5(wp_json_encode($state['tax_filters'])) : '0';
+
+        return sprintf(
+            'ap_dir:%s:v%s:letter=%s:s=%s:tax=%s:page=%d:pp=%d',
+            self::POST_TYPE,
+            $version,
+            rawurlencode($state['letter']),
+            $search_hash,
+            $tax_hash,
+            $state['paged'],
+            $state['per_page']
+        );
+    }
+
+    private static function get_cache_version(): int
+    {
+        $versions = get_option(self::CACHE_OPTION, []);
+        if (!is_array($versions)) {
+            $versions = [];
+        }
+
+        return isset($versions[self::POST_TYPE]) ? (int) $versions[self::POST_TYPE] : 1;
+    }
+
+    private static function bump_cache_version(): void
+    {
+        $versions = get_option(self::CACHE_OPTION, []);
+        if (!is_array($versions)) {
+            $versions = [];
+        }
+
+        $current = isset($versions[self::POST_TYPE]) ? (int) $versions[self::POST_TYPE] : 1;
+        $versions[self::POST_TYPE] = $current + 1;
+
+        update_option(self::CACHE_OPTION, $versions, false);
+    }
+
+    private static function flush_cache_on_save(int $post_id, WP_Post $post, bool $update): void
+    {
+        if ($post->post_type !== self::POST_TYPE) {
+            return;
+        }
+
+        self::bump_cache_version();
+    }
+
+    private static function flush_cache_on_status(string $new_status, string $old_status, WP_Post $post): void
+    {
+        if ($post->post_type !== self::POST_TYPE) {
+            return;
+        }
+
+        if ($new_status !== $old_status) {
+            self::bump_cache_version();
+        }
+    }
+
+    private static function flush_cache_on_terms(int $object_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids): void
+    {
+        if (get_post_type($object_id) !== self::POST_TYPE) {
+            return;
+        }
+
+        self::bump_cache_version();
+    }
+
+    private static function flush_cache_on_meta($meta_id, int $object_id, $meta_key = '', $meta_value = ''): void
+    {
+        if (get_post_type($object_id) !== self::POST_TYPE) {
+            return;
+        }
+
+        self::bump_cache_version();
+    }
+
+    private static function locate_template(): string
     {
         $candidates = [
-            'org_display_name',
-            '_org_display_name',
-            'ap_org_display_name',
-            '_ap_org_display_name',
+            'artpulse/directory-item-' . self::POST_TYPE . '.php',
+            'artpulse/directory-item.php',
         ];
 
-        foreach ($candidates as $meta_key) {
-            $value = get_post_meta($post_id, $meta_key, true);
-            if (is_string($value) && $value !== '') {
-                return $value;
+        $template = locate_template($candidates);
+        if (!is_string($template) || '' === $template) {
+            $template = plugin_dir_path(ARTPULSE_PLUGIN_FILE) . 'templates/partials/directory-item.php';
+        }
+
+        return $template;
+    }
+
+    private static function parse_tax_filters(): array
+    {
+        $filters = [];
+        if (!isset($_GET['tax'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return $filters;
+        }
+
+        $raw = wp_unslash($_GET['tax']); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if (!is_array($raw)) {
+            return $filters;
+        }
+
+        foreach ($raw as $taxonomy => $terms) {
+            $taxonomy = sanitize_key($taxonomy);
+            if ('' === $taxonomy) {
+                continue;
+            }
+
+            $terms = is_array($terms) ? $terms : explode(',', (string) $terms);
+            $terms = array_filter(array_map(static function ($term) {
+                $term = is_string($term) ? sanitize_title($term) : '';
+                return $term;
+            }, $terms));
+
+            if (!empty($terms)) {
+                $filters[$taxonomy] = array_values($terms);
             }
         }
 
-        $title = get_post_field('post_title', $post_id);
-        return is_string($title) ? $title : '';
-    }
-
-    private static function get_excerpt(int $post_id): string
-    {
-        $excerpt = get_post_field('post_excerpt', $post_id);
-        if (!is_string($excerpt) || $excerpt === '') {
-            $content = get_post_field('post_content', $post_id);
-            $excerpt = is_string($content) ? wp_strip_all_tags($content) : '';
-        }
-
-        return wp_html_excerpt($excerpt, 140, '&hellip;');
-    }
-
-    private static function get_badges(int $post_id, array $taxonomy_filter): array
-    {
-        $badges = [];
-
-        $address = get_post_meta($post_id, '_ap_org_address', true);
-        if (is_string($address) && $address !== '') {
-            $badges[] = $address;
-        }
-
-        $taxonomies = ['organization_category'];
-        if (!empty($taxonomy_filter)) {
-            $taxonomies[] = $taxonomy_filter['taxonomy'];
-        }
-
-        $taxonomies = array_unique(array_filter($taxonomies));
-
-        foreach ($taxonomies as $taxonomy) {
-            $terms = get_the_terms($post_id, $taxonomy);
-            if (is_array($terms)) {
-                foreach ($terms as $term) {
-                    $badges[] = $term->name;
-                }
-            }
-        }
-
-        return array_values(array_unique(array_filter($badges, static function ($badge) {
-            return is_string($badge) && $badge !== '';
-        })));
-    }
-
-    private static function prepare_card_markup(array $item): string
-    {
-        $classes = ['ap-card'];
-        $classes[] = 'ap-card--letter-' . sanitize_html_class(strtolower($item['letter']));
-
-        $attributes = [
-            'class'       => implode(' ', array_map('sanitize_html_class', $classes)),
-            'data-letter' => $item['letter'],
-            'data-search' => $item['search_index'],
-        ];
-
-        $html = '<article';
-        foreach ($attributes as $key => $value) {
-            $html .= ' ' . $key . '="' . esc_attr($value) . '"';
-        }
-        $html .= '>';
-
-        if (!empty($item['thumbnail'])) {
-            $html .= '<div class="ap-card__thumb"><img src="' . esc_url($item['thumbnail']) . '" alt="" loading="lazy" /></div>';
-        }
-
-        $html .= '<div class="ap-card__body">';
-        $html .= '<h3 class="ap-card__title"><a href="' . esc_url($item['permalink']) . '">' . esc_html($item['name']) . '</a></h3>';
-
-        if (!empty($item['excerpt'])) {
-            $html .= '<p class="ap-card__excerpt">' . esc_html($item['excerpt']) . '</p>';
-        }
-
-        if (!empty($item['badges'])) {
-            $html .= '<div class="ap-card__badges">';
-            foreach ($item['badges'] as $badge) {
-                $html .= '<span class="ap-badge">' . esc_html($badge) . '</span>';
-            }
-            $html .= '</div>';
-        }
-
-        if (!empty($item['is_favorited'])) {
-            $html .= '<div class="ap-card__favorite">' . esc_html__('★ Favorited', 'artpulse') . '</div>';
-        }
-
-        $html .= '</div>';
-        $html .= '</article>';
-
-        return $html;
-    }
-
-    private static function serialize_tax_filter(array $taxonomy_filter): string
-    {
-        if (empty($taxonomy_filter)) {
-            return '';
-        }
-
-        return $taxonomy_filter['taxonomy'] . ':' . implode(',', $taxonomy_filter['terms']);
+        return $filters;
     }
 }

--- a/templates/partials/directory-item.php
+++ b/templates/partials/directory-item.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Directory item partial for ArtPulse directories.
+ *
+ * @var array   $item_data  The prepared data for the directory card.
+ * @var WP_Post $item_post  The post object being rendered.
+ * @var string  $post_type  The post type slug.
+ */
+
+if (!isset($item_data) || !is_array($item_data)) {
+    return;
+}
+
+$thumbnail = $item_data['thumbnail'] ?? '';
+$permalink = isset($item_data['permalink']) ? $item_data['permalink'] : '';
+$title     = isset($item_data['title']) ? $item_data['title'] : '';
+$excerpt   = isset($item_data['excerpt']) ? $item_data['excerpt'] : '';
+$meta      = isset($item_data['meta']) && is_array($item_data['meta']) ? $item_data['meta'] : [];
+?>
+<li class="ap-directory__item">
+    <article class="ap-directory__card">
+        <?php if (!empty($thumbnail)) : ?>
+            <figure class="ap-directory__thumb">
+                <?php echo wp_kses_post($thumbnail); ?>
+            </figure>
+        <?php endif; ?>
+        <div class="ap-directory__body">
+            <h3 class="ap-directory__title">
+                <a href="<?php echo esc_url($permalink); ?>">
+                    <?php echo esc_html($title); ?>
+                </a>
+            </h3>
+            <?php if (!empty($excerpt)) : ?>
+                <p class="ap-directory__excerpt"><?php echo esc_html($excerpt); ?></p>
+            <?php endif; ?>
+            <?php if (!empty($meta)) : ?>
+                <p class="ap-directory__meta">
+                    <?php echo esc_html(implode(' • ', array_filter(array_map('trim', $meta)))); ?>
+                </p>
+            <?php endif; ?>
+        </div>
+    </article>
+</li>

--- a/tests/Core/TitleToolsTest.php
+++ b/tests/Core/TitleToolsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use ArtPulse\Core\TitleTools;
+use WP_UnitTestCase;
+
+class TitleToolsTest extends WP_UnitTestCase
+{
+    public function test_diacritics_are_normalized()
+    {
+        $this->assertSame('E', TitleTools::normalizeLetter('Édouard Manet'));
+    }
+
+    public function test_leading_articles_are_removed()
+    {
+        $this->assertSame('A', TitleTools::normalizeLetter('The Armory Show'));
+    }
+
+    public function test_symbols_fall_back_to_hash()
+    {
+        $this->assertSame('#', TitleTools::normalizeLetter('#42 Exhibition'));
+    }
+
+    public function test_non_latin_characters_fall_back_to_hash()
+    {
+        $this->assertSame('#', TitleTools::normalizeLetter('東京ギャラリー'));
+    }
+}

--- a/tests/Frontend/DirectoryCacheTest.php
+++ b/tests/Frontend/DirectoryCacheTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use ArtPulse\Frontend\ArtistsDirectory;
+use WP_UnitTestCase;
+
+class DirectoryCacheTest extends WP_UnitTestCase
+{
+    private array $capturedKeys = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $wpdb;
+        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_ap_dir:%'");
+        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_ap_dir:%'");
+        delete_option('ap_directory_cache_versions');
+
+        $this->capturedKeys = [];
+        add_filter('ap_directory_cache_key', [ $this, 'captureCacheKey' ], 10, 3);
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        remove_filter('ap_directory_cache_key', [ $this, 'captureCacheKey' ]);
+        parent::tearDown();
+    }
+
+    public function captureCacheKey($key, $state = [], $post_type = '')
+    {
+        $this->capturedKeys[] = $key;
+        return $key;
+    }
+
+    public function test_cache_key_changes_when_artist_title_updates()
+    {
+        $post_id = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Artist',
+            'post_status'=> 'publish',
+        ]);
+
+        $_GET['letter'] = 'A';
+        ArtistsDirectory::render_shortcode(['per_page' => 5]);
+        unset($_GET['letter']);
+
+        $this->assertNotEmpty($this->capturedKeys);
+        $first_key = end($this->capturedKeys);
+
+        wp_update_post([
+            'ID'         => $post_id,
+            'post_title' => 'Apex Artist',
+        ]);
+
+        $_GET['letter'] = 'A';
+        ArtistsDirectory::render_shortcode(['per_page' => 5]);
+        unset($_GET['letter']);
+
+        $second_key = end($this->capturedKeys);
+        $this->assertNotSame($first_key, $second_key);
+    }
+
+    public function test_cache_key_changes_when_artist_terms_update()
+    {
+        $term = self::factory()->term->create([
+            'taxonomy' => 'artist_specialty',
+            'name'     => 'Painting',
+            'slug'     => 'painting',
+        ]);
+
+        $post_id = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Artist',
+            'post_status'=> 'publish',
+        ]);
+
+        $_GET['letter'] = 'A';
+        ArtistsDirectory::render_shortcode(['per_page' => 5]);
+        unset($_GET['letter']);
+
+        $first_key = end($this->capturedKeys);
+
+        wp_set_object_terms($post_id, [$term], 'artist_specialty', true);
+
+        $_GET['letter'] = 'A';
+        ArtistsDirectory::render_shortcode(['per_page' => 5]);
+        unset($_GET['letter']);
+
+        $second_key = end($this->capturedKeys);
+        $this->assertNotSame($first_key, $second_key);
+    }
+
+    public function test_cache_key_changes_when_artist_meta_updates()
+    {
+        $post_id = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Artist',
+            'post_status'=> 'publish',
+        ]);
+
+        $_GET['letter'] = 'A';
+        ArtistsDirectory::render_shortcode(['per_page' => 5]);
+        unset($_GET['letter']);
+
+        $first_key = end($this->capturedKeys);
+
+        update_post_meta($post_id, '_ap_artist_location', 'New York');
+
+        $_GET['letter'] = 'A';
+        ArtistsDirectory::render_shortcode(['per_page' => 5]);
+        unset($_GET['letter']);
+
+        $second_key = end($this->capturedKeys);
+        $this->assertNotSame($first_key, $second_key);
+    }
+}

--- a/tests/Frontend/DirectoryQueryTest.php
+++ b/tests/Frontend/DirectoryQueryTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use ArtPulse\Core\TitleTools;
+use ArtPulse\Frontend\ArtistsDirectory;
+use ArtPulse\Frontend\OrgsDirectory;
+use WP_UnitTestCase;
+
+class DirectoryQueryTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $wpdb;
+        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_ap_dir:%'");
+        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_ap_dir:%'");
+        delete_option('ap_directory_cache_versions');
+        $_GET = [];
+    }
+
+    public function test_artists_letter_filter_returns_expected_results()
+    {
+        $alpha = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Artist',
+            'post_status'=> 'publish',
+        ]);
+        $beta = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Beta Artist',
+            'post_status'=> 'publish',
+        ]);
+
+        TitleTools::update_post_letter($alpha);
+        TitleTools::update_post_letter($beta);
+
+        $_GET['letter'] = 'A';
+        $output = ArtistsDirectory::render_shortcode(['per_page' => 10]);
+        unset($_GET['letter']);
+
+        $this->assertStringContainsString('Alpha Artist', $output);
+        $this->assertStringNotContainsString('Beta Artist', $output);
+    }
+
+    public function test_artists_letter_and_search_combination()
+    {
+        $alpha = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Painter',
+            'post_status'=> 'publish',
+        ]);
+        $beta = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Sculptor',
+            'post_status'=> 'publish',
+        ]);
+
+        TitleTools::update_post_letter($alpha);
+        TitleTools::update_post_letter($beta);
+
+        $_GET['letter'] = 'A';
+        $_GET['s'] = 'Painter';
+        $output = ArtistsDirectory::render_shortcode(['per_page' => 10]);
+        unset($_GET['letter'], $_GET['s']);
+
+        $this->assertStringContainsString('Alpha Painter', $output);
+        $this->assertStringNotContainsString('Alpha Sculptor', $output);
+    }
+
+    public function test_artists_taxonomy_filter_with_letter()
+    {
+        $term = self::factory()->term->create([
+            'taxonomy' => 'artist_specialty',
+            'slug'     => 'painting',
+            'name'     => 'Painting',
+        ]);
+
+        $alpha = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Painter',
+            'post_status'=> 'publish',
+        ]);
+        $beta = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Writer',
+            'post_status'=> 'publish',
+        ]);
+
+        wp_set_object_terms($alpha, [$term], 'artist_specialty');
+
+        TitleTools::update_post_letter($alpha);
+        TitleTools::update_post_letter($beta);
+
+        $_GET['letter'] = 'A';
+        $_GET['tax'] = [ 'artist_specialty' => ['painting'] ];
+        $output = ArtistsDirectory::render_shortcode(['per_page' => 10]);
+        unset($_GET['letter'], $_GET['tax']);
+
+        $this->assertStringContainsString('Alpha Painter', $output);
+        $this->assertStringNotContainsString('Alpha Writer', $output);
+    }
+
+    public function test_artists_all_bucket_includes_all_letters()
+    {
+        $alpha = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha Artist',
+            'post_status'=> 'publish',
+        ]);
+        $beta = self::factory()->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Beta Artist',
+            'post_status'=> 'publish',
+        ]);
+
+        TitleTools::update_post_letter($alpha);
+        TitleTools::update_post_letter($beta);
+
+        $_GET['letter'] = 'all';
+        $output = ArtistsDirectory::render_shortcode(['per_page' => 10]);
+        unset($_GET['letter']);
+
+        $this->assertStringContainsString('Alpha Artist', $output);
+        $this->assertStringContainsString('Beta Artist', $output);
+    }
+
+    public function test_rewrite_letter_request_sets_query_var()
+    {
+        $page_id = self::factory()->post->create([
+            'post_type'  => 'page',
+            'post_title' => 'Artists',
+            'post_name'  => 'artists',
+            'post_status'=> 'publish',
+        ]);
+
+        do_action('init');
+        flush_rewrite_rules(false);
+
+        $this->go_to(home_url('/artists/a/'));
+
+        $this->assertSame('A', get_query_var('letter'));
+        $this->assertEquals($page_id, get_queried_object_id());
+    }
+
+    public function test_organization_directory_outputs_results()
+    {
+        $gallery = self::factory()->post->create([
+            'post_type'  => 'artpulse_org',
+            'post_title' => 'Gallery Example',
+            'post_status'=> 'publish',
+        ]);
+
+        TitleTools::update_post_letter($gallery);
+
+        $_GET['letter'] = 'G';
+        $output = OrgsDirectory::render_shortcode(['per_page' => 10]);
+        unset($_GET['letter']);
+
+        $this->assertStringContainsString('Gallery Example', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add TitleTools utilities and rewrite integration for letter-aware directory navigation, canonical URLs, and sitemap exposure
- rebuild the artist and organization directory shortcodes with accessible letter navigation, search, caching, and shared templates
- add PHPUnit coverage for normalization logic, directory queries, and cache invalidation behaviour

## Testing
- not run (phpunit dependencies could not be installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2742be910832ea226498dbee1009b