### PR TITLE
Normalize title letters with Unicode decomposition

### DIFF
--- a/src/Core/TitleTools.php
+++ b/src/Core/TitleTools.php
@@ -50,6 +50,19 @@ class TitleTools
             }
         }
 
+        if (class_exists('\\Normalizer')) {
+            $normalized = \Normalizer::normalize($working, \Normalizer::FORM_D);
+            if (is_string($normalized)) {
+                $stripped = preg_replace('/\p{Mn}+/u', '', $normalized);
+                if (is_string($stripped)) {
+                    $working = $stripped;
+                } else {
+                    $working = $normalized;
+                }
+            }
+        }
+
+        $working = trim($working);
         if ('' === $working) {
             return '#';
         }
@@ -64,7 +77,25 @@ class TitleTools
             return '#';
         }
 
-        $first = strtoupper(substr($transliterated, 0, 1));
+        if (function_exists('mb_substr')) {
+            $first = mb_substr($transliterated, 0, 1, 'UTF-8');
+            if (false === $first) {
+                $first = substr($transliterated, 0, 1);
+            }
+        } else {
+            $first = substr($transliterated, 0, 1);
+        }
+
+        if (function_exists('mb_strtoupper')) {
+            $upper = mb_strtoupper($first, 'UTF-8');
+            if (false === $upper) {
+                $upper = strtoupper($first);
+            }
+        } else {
+            $upper = strtoupper($first);
+        }
+
+        $first = $upper;
         $first = apply_filters('ap_letter_map', $first, $title, $locale);
 
         return preg_match('/^[A-Z]$/', $first) ? $first : '#';

--- a/tests/Core/TitleToolsTest.php
+++ b/tests/Core/TitleToolsTest.php
@@ -10,6 +10,16 @@ class TitleToolsTest extends WP_UnitTestCase
         $this->assertSame('E', TitleTools::normalizeLetter('Édouard Manet'));
     }
 
+    public function test_combining_diacritics_are_stripped()
+    {
+        $this->assertSame('E', TitleTools::normalizeLetter("E\u{0301}mile Bernard"));
+    }
+
+    public function test_extended_latin_characters_are_transliterated()
+    {
+        $this->assertSame('L', TitleTools::normalizeLetter('Łódź Collective'));
+    }
+
     public function test_leading_articles_are_removed()
     {
         $this->assertSame('A', TitleTools::normalizeLetter('The Armory Show'));
@@ -23,5 +33,10 @@ class TitleToolsTest extends WP_UnitTestCase
     public function test_non_latin_characters_fall_back_to_hash()
     {
         $this->assertSame('#', TitleTools::normalizeLetter('東京ギャラリー'));
+    }
+
+    public function test_korean_titles_fall_back_to_hash()
+    {
+        $this->assertSame('#', TitleTools::normalizeLetter('서울미술관'));
     }
 }


### PR DESCRIPTION
## Summary
- normalize stripped titles with Unicode decomposition and remove combining marks before deriving the directory letter
- switch the first-character extraction to multibyte-safe helpers with graceful fallbacks when mbstring is unavailable
- expand TitleTools unit coverage to cover combining accents and additional non-Latin scripts

## Testing
- Unable to run `vendor/bin/phpunit --testsuite Core --filter TitleToolsTest` (missing vendor/bin/phpunit; `composer install` blocked by network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e27bf660b8832eb2532c739d3c3808