### PR TITLE
Improve directory results live region accessibility

### DIFF
--- a/src/Frontend/ArtistsDirectory.php
+++ b/src/Frontend/ArtistsDirectory.php
@@ -166,7 +166,14 @@ class ArtistsDirectory
             <p class="ap-directory__announce" aria-live="polite" aria-atomic="true">
                 <?php echo esc_html($summary); ?>
             </p>
-            <div id="ap-artists-directory-results" class="ap-directory__results" tabindex="-1">
+            <div
+                id="ap-artists-directory-results"
+                class="ap-directory__results"
+                tabindex="-1"
+                role="region"
+                aria-live="polite"
+                aria-label="<?php echo esc_attr__('Artists directory results', 'artpulse-management'); ?>"
+            >
                 <h2 class="ap-directory__heading">
                     <?php echo esc_html($heading); ?>
                 </h2>
@@ -313,6 +320,7 @@ class ArtistsDirectory
                 name="s"
                 value="<?php echo esc_attr($search_value); ?>"
                 placeholder="<?php echo esc_attr__('Search artists', 'artpulse-management'); ?>"
+                aria-controls="ap-artists-directory-results"
             />
             <input type="hidden" name="letter" value="<?php echo esc_attr($letter_value); ?>" />
             <?php foreach ($state['tax_filters'] as $taxonomy => $terms) :

--- a/src/Frontend/OrgsDirectory.php
+++ b/src/Frontend/OrgsDirectory.php
@@ -166,7 +166,14 @@ class OrgsDirectory
             <p class="ap-directory__announce" aria-live="polite" aria-atomic="true">
                 <?php echo esc_html($summary); ?>
             </p>
-            <div id="ap-orgs-directory-results" class="ap-directory__results" tabindex="-1">
+            <div
+                id="ap-orgs-directory-results"
+                class="ap-directory__results"
+                tabindex="-1"
+                role="region"
+                aria-live="polite"
+                aria-label="<?php echo esc_attr__('Galleries directory results', 'artpulse-management'); ?>"
+            >
                 <h2 class="ap-directory__heading">
                     <?php echo esc_html($heading); ?>
                 </h2>
@@ -304,6 +311,7 @@ class OrgsDirectory
                 name="s"
                 value="<?php echo esc_attr($search_value); ?>"
                 placeholder="<?php echo esc_attr__('Search galleries', 'artpulse-management'); ?>"
+                aria-controls="ap-orgs-directory-results"
             />
             <input type="hidden" name="letter" value="<?php echo esc_attr($letter_value); ?>" />
             <?php foreach ($state['tax_filters'] as $taxonomy => $terms) :


### PR DESCRIPTION
## Summary
- add ARIA live region semantics to the artists and galleries directory results containers
- connect each directory search input with its respective results region for assistive tech context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27c016778832eb69a06b61f3a8082