### PR TITLE
Add WP-CLI command for backfilling directory letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Run the test suite with:
 vendor/bin/phpunit --testdox
 ```
 
+### WP-CLI utilities
+
+Backfill missing directory letter metadata with:
+
+```bash
+wp artpulse backfill-letters --post_type=artpulse_artist --batch=100
+```
+
+`--post_type` defaults to `artpulse_artist` and `--batch` controls how many
+posts are processed per query.
+
 Optional tools:
 
 phpunit for unit tests

--- a/artpulse-management.php
+++ b/artpulse-management.php
@@ -11,6 +11,7 @@
 use ArtPulse\Core\Plugin;
 use ArtPulse\Core\WooCommerceIntegration;
 use ArtPulse\Admin\EnqueueAssets;
+use ArtPulse\Tools\CLI\BackfillLetters;
 
 // Suppress deprecated notices if WP_DEBUG enabled
 if (defined('WP_DEBUG') && WP_DEBUG) {
@@ -70,6 +71,11 @@ $plugin = new WooCommerceIntegration();
 add_action('rest_api_init', function () {
     \ArtPulse\Rest\PortfolioRestController::register();
 });
+
+if (defined('WP_CLI') && WP_CLI) {
+    require_once __DIR__ . '/tools/cli/BackfillLetters.php';
+    \WP_CLI::add_command('artpulse backfill-letters', [BackfillLetters::class, 'handle']);
+}
 
 function artpulse_create_custom_table() {
     global $wpdb;

--- a/tests/Core/BackfillLettersCommandTest.php
+++ b/tests/Core/BackfillLettersCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use ArtPulse\Core\TitleTools;
+use ArtPulse\Tools\CLI\BackfillLetters;
+use WP_UnitTestCase;
+
+if (!defined('WP_CLI')) {
+    define('WP_CLI', true);
+}
+
+if (!class_exists('\\WP_CLI')) {
+    class WP_CLI
+    {
+        /** @var array<string, callable> */
+        public static array $commands = [];
+
+        public static string $last_message = '';
+
+        public static function add_command(string $name, callable $callable): void
+        {
+            self::$commands[$name] = $callable;
+        }
+
+        public static function runcommand(string $command, array $assoc_args = []): void
+        {
+            if (!isset(self::$commands[$command])) {
+                throw new RuntimeException(sprintf('Command "%s" not registered.', $command));
+            }
+
+            call_user_func(self::$commands[$command], [], $assoc_args);
+        }
+
+        public static function error(string $message): void
+        {
+            throw new RuntimeException($message);
+        }
+
+        public static function success(string $message): void
+        {
+            self::$last_message = $message;
+        }
+    }
+}
+
+require_once dirname(__DIR__, 2) . '/tools/cli/BackfillLetters.php';
+
+class BackfillLettersCommandTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \WP_CLI::$commands = [];
+        \WP_CLI::$last_message = '';
+        \WP_CLI::add_command('artpulse backfill-letters', [BackfillLetters::class, 'handle']);
+    }
+
+    public function test_command_backfills_missing_letters(): void
+    {
+        $factory = self::factory();
+
+        $needs_letter = $factory->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Beta',
+            'post_status' => 'publish',
+        ]);
+        delete_post_meta($needs_letter, TitleTools::META_KEY);
+
+        $already_set = $factory->post->create([
+            'post_type'  => 'artpulse_artist',
+            'post_title' => 'Alpha',
+            'post_status' => 'publish',
+        ]);
+        update_post_meta($already_set, TitleTools::META_KEY, 'A');
+
+        \WP_CLI::runcommand('artpulse backfill-letters', [
+            'post_type' => 'artpulse_artist',
+            'batch'     => 1,
+        ]);
+
+        $this->assertSame('B', get_post_meta($needs_letter, TitleTools::META_KEY, true));
+        $this->assertSame('A', get_post_meta($already_set, TitleTools::META_KEY, true));
+        $this->assertStringContainsString('Updated 1 posts', \WP_CLI::$last_message);
+    }
+}
+

--- a/tools/cli/BackfillLetters.php
+++ b/tools/cli/BackfillLetters.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace ArtPulse\Tools\CLI;
+
+use ArtPulse\Core\TitleTools;
+
+/**
+ * WP-CLI command for backfilling cached directory letters.
+ */
+class BackfillLetters
+{
+    /**
+     * Handle the registered WP-CLI command.
+     *
+     * @param array $args       Positional arguments (unused).
+     * @param array $assoc_args Associative arguments (post_type, batch).
+     */
+    public static function handle(array $args, array $assoc_args): void
+    {
+        $assoc_args = wp_parse_args($assoc_args, [
+            'post_type' => 'artpulse_artist',
+            'batch'     => 100,
+        ]);
+
+        try {
+            $processed = self::run((string) $assoc_args['post_type'], (int) $assoc_args['batch']);
+        } catch (\InvalidArgumentException $exception) {
+            if (class_exists('\\WP_CLI')) {
+                \WP_CLI::error($exception->getMessage());
+            }
+
+            return;
+        }
+
+        if (!class_exists('\\WP_CLI')) {
+            return;
+        }
+
+        if (0 === $processed) {
+            \WP_CLI::success(sprintf('No posts required updates for "%s".', $assoc_args['post_type']));
+            return;
+        }
+
+        \WP_CLI::success(sprintf('Updated %d posts for "%s".', $processed, $assoc_args['post_type']));
+    }
+
+    /**
+     * Execute the backfill routine and return the number of processed posts.
+     */
+    public static function run(string $post_type, int $batch = 100): int
+    {
+        $post_type = sanitize_key($post_type);
+        if ('' === $post_type) {
+            throw new \InvalidArgumentException('A valid post type is required.');
+        }
+
+        $batch = max(1, $batch);
+        $processed = 0;
+
+        do {
+            $ids = TitleTools::get_posts_missing_letter_ids($post_type, $batch);
+            if (empty($ids)) {
+                break;
+            }
+
+            foreach ($ids as $post_id) {
+                $post = get_post((int) $post_id);
+                if ($post && $post->post_type === $post_type) {
+                    TitleTools::update_post_letter((int) $post->ID, $post->post_title);
+                    $processed++;
+                }
+            }
+        } while (count($ids) === $batch);
+
+        return $processed;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a WP-CLI command that reuses the TitleTools helper to backfill letter metadata in batches
- register the command in the plugin bootstrap and document the usage in the README
- cover the command with a smoke test that exercises it via WP_CLI::runcommand

## Testing
- vendor/bin/phpunit *(fails: dependencies not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27ccb7a24832e9e030375069f5e30