### PR TITLE
Add pretty /letter/ rewrite routes for directories

### DIFF
--- a/src/Core/Rewrites.php
+++ b/src/Core/Rewrites.php
@@ -13,6 +13,7 @@ class Rewrites
      */
     public static function register(): void
     {
+        add_action('init', [self::class, 'add_rewrite_tags']);
         add_action('init', [self::class, 'add_rewrite_rules']);
         add_action('init', [self::class, 'register_directory_sitemap_route']);
         add_filter('query_vars', [self::class, 'register_query_vars']);
@@ -22,20 +23,36 @@ class Rewrites
     }
 
     /**
+     * Register rewrite tags used by the directory rewrites.
+     */
+    public static function add_rewrite_tags(): void
+    {
+        add_rewrite_tag('%ap_letter%', '([A-Za-z]|%23|#|all)');
+    }
+
+    /**
      * Register rewrite rules for artist and gallery directory letters.
      */
     public static function add_rewrite_rules(): void
     {
         $artists_base = self::get_directory_base_slug('artists');
         $orgs_base    = self::get_directory_base_slug('galleries');
-        $pattern      = '([A-Za-z]|%23|#|all)';
+        $pattern      = 'letter/([A-Za-z]|%23|#|all)';
 
         if ($artists_base !== '') {
-            add_rewrite_rule('^' . $artists_base . '/' . $pattern . '/?$', 'index.php?pagename=' . $artists_base . '&letter=$matches[1]&ap_directory=artists', 'top');
+            add_rewrite_rule(
+                '^' . $artists_base . '/' . $pattern . '/?$',
+                'index.php?pagename=' . $artists_base . '&ap_letter=$matches[1]&ap_directory=artists',
+                'top'
+            );
         }
 
         if ($orgs_base !== '') {
-            add_rewrite_rule('^' . $orgs_base . '/' . $pattern . '/?$', 'index.php?pagename=' . $orgs_base . '&letter=$matches[1]&ap_directory=galleries', 'top');
+            add_rewrite_rule(
+                '^' . $orgs_base . '/' . $pattern . '/?$',
+                'index.php?pagename=' . $orgs_base . '&ap_letter=$matches[1]&ap_directory=galleries',
+                'top'
+            );
         }
     }
 
@@ -52,6 +69,7 @@ class Rewrites
      */
     public static function register_query_vars(array $vars): array
     {
+        $vars[] = 'ap_letter';
         $vars[] = 'letter';
         $vars[] = 'ap_directory';
         $vars[] = self::DIRECTORY_SITEMAP_QUERY;
@@ -161,8 +179,7 @@ class Rewrites
             $segment = rawurlencode('#');
         }
 
-        $path = trailingslashit($base);
-        $path .= trailingslashit($segment);
+        $path = trailingslashit($base) . 'letter/' . trailingslashit($segment);
 
         $url = home_url('/' . ltrim($path, '/'));
         if (!empty($query)) {

--- a/src/Frontend/OrgsDirectory.php
+++ b/src/Frontend/OrgsDirectory.php
@@ -71,7 +71,13 @@ class OrgsDirectory
 
         $per_page = max(1, (int) $atts['per_page']);
 
-        $requested_letter = get_query_var('letter');
+        $requested_letter = get_query_var('ap_letter');
+        if ('' === $requested_letter) {
+            $requested_letter = get_query_var('letter');
+        }
+        if ('' === $requested_letter && isset($_GET['ap_letter'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $requested_letter = sanitize_text_field(wp_unslash((string) $_GET['ap_letter']));
+        }
         if ('' === $requested_letter && isset($_GET['letter'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
             $requested_letter = sanitize_text_field(wp_unslash((string) $_GET['letter']));
         }
@@ -297,7 +303,7 @@ class OrgsDirectory
     {
         $action = Rewrites::get_directory_letter_url('galleries', $state['letter']);
         $search_value = $state['search'];
-        $letter_value = $state['letter'];
+        $permalink_structure = (string) get_option('permalink_structure');
 
         ob_start();
         ?>
@@ -313,7 +319,9 @@ class OrgsDirectory
                 placeholder="<?php echo esc_attr__('Search galleries', 'artpulse-management'); ?>"
                 aria-controls="ap-orgs-directory-results"
             />
-            <input type="hidden" name="letter" value="<?php echo esc_attr($letter_value); ?>" />
+            <?php if ('' === $permalink_structure) : ?>
+                <input type="hidden" name="ap_letter" value="<?php echo esc_attr($state['letter']); ?>" />
+            <?php endif; ?>
             <?php foreach ($state['tax_filters'] as $taxonomy => $terms) :
                 foreach ($terms as $term) : ?>
                     <input type="hidden" name="tax[<?php echo esc_attr($taxonomy); ?>][]" value="<?php echo esc_attr($term); ?>" />
@@ -428,8 +436,6 @@ class OrgsDirectory
     private static function build_letter_url(string $letter, array $state): string
     {
         $query = self::build_canonical_query_args($state, false);
-        $query['letter'] = $letter;
-        unset($query['paged']);
 
         return Rewrites::get_directory_letter_url('galleries', $letter, $query);
     }

--- a/tests/Frontend/DirectoryQueryTest.php
+++ b/tests/Frontend/DirectoryQueryTest.php
@@ -33,9 +33,9 @@ class DirectoryQueryTest extends WP_UnitTestCase
         TitleTools::update_post_letter($alpha);
         TitleTools::update_post_letter($beta);
 
-        $_GET['letter'] = 'A';
+        $_GET['ap_letter'] = 'A';
         $output = ArtistsDirectory::render_shortcode(['per_page' => 10]);
-        unset($_GET['letter']);
+        unset($_GET['ap_letter']);
 
         $this->assertStringContainsString('Alpha Artist', $output);
         $this->assertStringNotContainsString('Beta Artist', $output);
@@ -135,10 +135,33 @@ class DirectoryQueryTest extends WP_UnitTestCase
         do_action('init');
         flush_rewrite_rules(false);
 
-        $this->go_to(home_url('/artists/a/'));
+        $this->go_to(home_url('/artists/letter/a/'));
 
-        $this->assertSame('A', get_query_var('letter'));
+        $this->assertSame('A', get_query_var('ap_letter'));
         $this->assertEquals($page_id, get_queried_object_id());
+    }
+
+    public function test_rewrite_honours_filtered_base_slug(): void
+    {
+        $page_id = self::factory()->post->create([
+            'post_type'  => 'page',
+            'post_title' => 'Organisations',
+            'post_name'  => 'organisations',
+            'post_status'=> 'publish',
+        ]);
+
+        $callback = static fn () => 'organisations';
+        add_filter('ap_galleries_directory_base', $callback);
+
+        do_action('init');
+        flush_rewrite_rules(false);
+
+        $this->go_to(home_url('/organisations/letter/b/'));
+
+        $this->assertSame('B', get_query_var('ap_letter'));
+        $this->assertEquals($page_id, get_queried_object_id());
+
+        remove_filter('ap_galleries_directory_base', $callback);
     }
 
     public function test_organization_directory_outputs_results()


### PR DESCRIPTION
## Summary
- register rewrite tags and /letter/ routes that populate a new `ap_letter` query var for artist and organisation directories
- update the directory state parser, canonical URLs, and search forms to prefer the new query var while preserving legacy support
- adjust directory tests to cover the new rewrites, including filtered base slugs and the `ap_letter` query parameter

## Testing
- composer test *(fails: vendor/bin/phpunit missing; composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28168ba18832ea0fe6eab46e7df3f