### PR TITLE
Add lastmod metadata to directory sitemap

### DIFF
--- a/src/Core/Rewrites.php
+++ b/src/Core/Rewrites.php
@@ -92,15 +92,25 @@ class Rewrites
         echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
         echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
-        foreach ($urls as $url) {
-            echo '  <url>' . "\n";
-            echo '    <loc>' . esc_url($url) . '</loc>' . "\n";
-            echo '    <changefreq>weekly</changefreq>' . "\n";
-            echo '  </url>' . "\n";
+        foreach ($urls as $type => $letter_urls) {
+            foreach ($letter_urls as $letter => $url) {
+                $lastmod = self::get_directory_letter_lastmod($type, $letter);
+                if (!$lastmod) {
+                    $lastmod = gmdate('c');
+                }
+
+                echo '  <url>' . "\n";
+                echo '    <loc>' . esc_url($url) . '</loc>' . "\n";
+                echo '    <lastmod>' . esc_html($lastmod) . '</lastmod>' . "\n";
+                echo '    <changefreq>weekly</changefreq>' . "\n";
+                echo '  </url>' . "\n";
+            }
         }
 
         echo '</urlset>';
-        exit;
+        if (apply_filters('ap_directory_sitemap_should_exit', true)) {
+            exit;
+        }
     }
 
     /**
@@ -197,9 +207,13 @@ class Rewrites
         $letters = array_merge(['all'], range('A', 'Z'), ['#']);
         $urls    = [];
 
-        foreach (['artists', 'galleries'] as $type) {
+        foreach (array_keys(self::get_directory_types()) as $type) {
             foreach ($letters as $letter) {
-                $urls[] = self::get_directory_letter_url($type, $letter);
+                if (!isset($urls[$type])) {
+                    $urls[$type] = [];
+                }
+
+                $urls[$type][$letter] = self::get_directory_letter_url($type, $letter);
             }
         }
 
@@ -212,5 +226,99 @@ class Rewrites
     public static function get_directory_sitemap_url(): string
     {
         return home_url('/sitemap-artpulse-directories.xml');
+    }
+
+    /**
+     * Map directory types to their corresponding post types.
+     */
+    private static function get_directory_types(): array
+    {
+        return [
+            'artists'   => 'artpulse_artist',
+            'galleries' => 'artpulse_org',
+        ];
+    }
+
+    /**
+     * Fetch the most recent modification time for a given directory letter bucket.
+     */
+    private static function get_directory_letter_lastmod(string $type, string $letter): ?string
+    {
+        static $cache = [];
+
+        $letter = strtolower($letter) === 'all' ? 'all' : ('#' === $letter ? '#' : strtoupper($letter));
+
+        if (!isset($cache[$type])) {
+            $cache[$type] = self::build_directory_letter_lastmod_cache($type);
+        }
+
+        $map = $cache[$type];
+
+        if ('all' === $letter) {
+            return $map['_all'] ?? null;
+        }
+
+        return $map[$letter] ?? ($map['_all'] ?? null);
+    }
+
+    /**
+     * Build a cache of last modification times keyed by directory letter.
+     */
+    private static function build_directory_letter_lastmod_cache(string $type): array
+    {
+        global $wpdb;
+
+        $types = self::get_directory_types();
+        if (!isset($types[$type])) {
+            return [];
+        }
+
+        $post_type = $types[$type];
+
+        $cache = [];
+
+        $all_modified = $wpdb->get_var($wpdb->prepare(
+            "SELECT MAX(post_modified_gmt) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+            $post_type
+        ));
+
+        if (!empty($all_modified)) {
+            $formatted = mysql2date('c', $all_modified, false);
+            if ($formatted) {
+                $cache['_all'] = $formatted;
+            }
+        }
+
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT COALESCE(NULLIF(m.meta_value, ''), '#') AS letter, MAX(p.post_modified_gmt) AS lastmod_gmt
+             FROM {$wpdb->posts} AS p
+             LEFT JOIN {$wpdb->postmeta} AS m ON (p.ID = m.post_id AND m.meta_key = %s)
+             WHERE p.post_type = %s AND p.post_status = 'publish'
+             GROUP BY COALESCE(NULLIF(m.meta_value, ''), '#')",
+            TitleTools::META_KEY,
+            $post_type
+        ), ARRAY_A);
+
+        if (!empty($rows)) {
+            foreach ($rows as $row) {
+                $letter = isset($row['letter']) ? (string) $row['letter'] : '#';
+                $letter = strtolower($letter) === 'all' ? 'all' : ('#' === $letter ? '#' : strtoupper($letter));
+
+                if ('all' !== $letter && '#' !== $letter && !preg_match('/^[A-Z]$/', $letter)) {
+                    continue;
+                }
+
+                if (empty($row['lastmod_gmt'])) {
+                    continue;
+                }
+
+                $formatted = mysql2date('c', $row['lastmod_gmt'], false);
+                if ($formatted) {
+                    $cache[$letter] = $formatted;
+                }
+            }
+        }
+
+        return $cache;
     }
 }

--- a/tests/Core/RewritesTest.php
+++ b/tests/Core/RewritesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use ArtPulse\Core\Rewrites;
+use ArtPulse\Core\TitleTools;
+use WP_UnitTestCase;
+
+class RewritesTest extends WP_UnitTestCase
+{
+    public function test_directory_sitemap_includes_lastmod_and_changefreq()
+    {
+        $artist_latest = '2024-01-05 12:00:00';
+        $gallery_latest = '2024-03-02 09:00:00';
+
+        $artist_id = self::factory()->post->create([
+            'post_type'         => 'artpulse_artist',
+            'post_status'       => 'publish',
+            'post_title'        => 'Alpha Artist',
+            'post_date'         => '2024-01-01 00:00:00',
+            'post_date_gmt'     => '2024-01-01 00:00:00',
+            'post_modified'     => $artist_latest,
+            'post_modified_gmt' => $artist_latest,
+        ]);
+        update_post_meta($artist_id, TitleTools::META_KEY, 'A');
+
+        $symbol_artist_id = self::factory()->post->create([
+            'post_type'         => 'artpulse_artist',
+            'post_status'       => 'publish',
+            'post_title'        => '# Symbol Artist',
+            'post_date'         => '2024-01-02 00:00:00',
+            'post_date_gmt'     => '2024-01-02 00:00:00',
+            'post_modified'     => '2024-01-04 00:00:00',
+            'post_modified_gmt' => '2024-01-04 00:00:00',
+        ]);
+        update_post_meta($symbol_artist_id, TitleTools::META_KEY, '#');
+
+        $gallery_id = self::factory()->post->create([
+            'post_type'         => 'artpulse_org',
+            'post_status'       => 'publish',
+            'post_title'        => 'Beta Gallery',
+            'post_date'         => '2024-02-01 00:00:00',
+            'post_date_gmt'     => '2024-02-01 00:00:00',
+            'post_modified'     => $gallery_latest,
+            'post_modified_gmt' => $gallery_latest,
+        ]);
+        update_post_meta($gallery_id, TitleTools::META_KEY, 'B');
+
+        set_query_var('ap_directory_sitemap', 1);
+
+        add_filter('ap_directory_sitemap_should_exit', '__return_false');
+        ob_start();
+        Rewrites::maybe_render_directory_sitemap();
+        $xml_output = ob_get_clean();
+        remove_filter('ap_directory_sitemap_should_exit', '__return_false');
+
+        $this->assertNotEmpty($xml_output);
+
+        $xml = new SimpleXMLElement($xml_output);
+        $this->assertSame('urlset', $xml->getName());
+
+        $this->assertCount(56, $xml->url);
+
+        foreach ($xml->url as $url_node) {
+            $this->assertNotEmpty((string) $url_node->lastmod);
+            $this->assertSame('weekly', (string) $url_node->changefreq);
+        }
+
+        $artist_url = $this->find_url_node($xml, home_url('/artists/letter/A/'));
+        $this->assertNotNull($artist_url);
+        $this->assertSame(gmdate('c', strtotime($artist_latest . ' UTC')), (string) $artist_url->lastmod);
+
+        $gallery_url = $this->find_url_node($xml, home_url('/galleries/letter/B/'));
+        $this->assertNotNull($gallery_url);
+        $this->assertSame(gmdate('c', strtotime($gallery_latest . ' UTC')), (string) $gallery_url->lastmod);
+    }
+
+    private function find_url_node(SimpleXMLElement $xml, string $loc): ?SimpleXMLElement
+    {
+        foreach ($xml->url as $url_node) {
+            if ((string) $url_node->loc === $loc) {
+                return $url_node;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- return directory letter URLs grouped by directory type and enrich the sitemap output with per-letter lastmod timestamps
- derive lastmod values from the latest modified posts per directory bucket and add a testing hook to disable the early exit during rendering
- add a PHPUnit test covering the generated sitemap structure and metadata for artist and gallery directory letters

## Testing
- php -l src/Core/Rewrites.php
- php -l tests/Core/RewritesTest.php


------
https://chatgpt.com/codex/tasks/task_e_68e283540128832e9fa6ca03c3297863