### PR TITLE
Add Composer validation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           tools: composer
           extensions: mbstring, mysqli
 
+      - name: Validate Composer configuration
+        run: composer validate --no-check-publish
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -153,3 +153,5 @@ Create a feature branch: git checkout -b feature/your-feature
 Submit a PR with a clear description
 
 Before committing changes that impact block assets, run `npm run build` and include the generated files in your commit. The CI workflow validates that the compiled bundles in `assets/js` and `assets/css` are up to date, and the build will fail if they are not.
+
+Run `composer validate --no-check-publish` before pushing updates to ensure the Composer metadata remains valid. The CI workflow stops early when the manifest contains errors.


### PR DESCRIPTION
## Summary
- add a Composer manifest validation step to the CI workflow so failures surface before installs
- document the new validation requirement in the contributor guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e285ba9254832ea92182f9ec4602ef