### PR TITLE
Add Playwright artifact uploads to community E2E workflow

### DIFF
--- a/.github/workflows/e2e-community.yml
+++ b/.github/workflows/e2e-community.yml
@@ -60,3 +60,32 @@ jobs:
             run('npx wp-env stop');
           }
           NODE
+
+      - name: Upload Playwright HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/**/*.zip
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Playwright screenshots and logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-screenshots-logs
+          path: |
+            test-results/**/*.png
+            test-results/**/*.log
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add failure-only artifact upload steps so Playwright reports are preserved for debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2863a76d4832eb1e35fd9b9c61621