### PR TITLE
Make directory cache flush callbacks callable by WordPress

### DIFF
--- a/src/Frontend/ArtistsDirectory.php
+++ b/src/Frontend/ArtistsDirectory.php
@@ -514,7 +514,7 @@ class ArtistsDirectory
         update_option(self::CACHE_OPTION, $versions, false);
     }
 
-    private static function flush_cache_on_save(int $post_id, WP_Post $post, bool $update): void
+    public static function flush_cache_on_save(int $post_id, WP_Post $post, bool $update): void
     {
         if ($post->post_type !== self::POST_TYPE) {
             return;
@@ -523,7 +523,7 @@ class ArtistsDirectory
         self::bump_cache_version();
     }
 
-    private static function flush_cache_on_status(string $new_status, string $old_status, WP_Post $post): void
+    public static function flush_cache_on_status(string $new_status, string $old_status, WP_Post $post): void
     {
         if ($post->post_type !== self::POST_TYPE) {
             return;
@@ -534,7 +534,7 @@ class ArtistsDirectory
         }
     }
 
-    private static function flush_cache_on_terms(int $object_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids): void
+    public static function flush_cache_on_terms(int $object_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids): void
     {
         if (get_post_type($object_id) !== self::POST_TYPE) {
             return;
@@ -543,7 +543,7 @@ class ArtistsDirectory
         self::bump_cache_version();
     }
 
-    private static function flush_cache_on_meta($meta_id, int $object_id, $meta_key = '', $meta_value = ''): void
+    public static function flush_cache_on_meta($meta_id, int $object_id, $meta_key = '', $meta_value = ''): void
     {
         if (get_post_type($object_id) !== self::POST_TYPE) {
             return;

--- a/src/Frontend/OrgsDirectory.php
+++ b/src/Frontend/OrgsDirectory.php
@@ -505,7 +505,7 @@ class OrgsDirectory
         update_option(self::CACHE_OPTION, $versions, false);
     }
 
-    private static function flush_cache_on_save(int $post_id, WP_Post $post, bool $update): void
+    public static function flush_cache_on_save(int $post_id, WP_Post $post, bool $update): void
     {
         if ($post->post_type !== self::POST_TYPE) {
             return;
@@ -514,7 +514,7 @@ class OrgsDirectory
         self::bump_cache_version();
     }
 
-    private static function flush_cache_on_status(string $new_status, string $old_status, WP_Post $post): void
+    public static function flush_cache_on_status(string $new_status, string $old_status, WP_Post $post): void
     {
         if ($post->post_type !== self::POST_TYPE) {
             return;
@@ -525,7 +525,7 @@ class OrgsDirectory
         }
     }
 
-    private static function flush_cache_on_terms(int $object_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids): void
+    public static function flush_cache_on_terms(int $object_id, array $terms, array $tt_ids, string $taxonomy, bool $append, array $old_tt_ids): void
     {
         if (get_post_type($object_id) !== self::POST_TYPE) {
             return;
@@ -534,7 +534,7 @@ class OrgsDirectory
         self::bump_cache_version();
     }
 
-    private static function flush_cache_on_meta($meta_id, int $object_id, $meta_key = '', $meta_value = ''): void
+    public static function flush_cache_on_meta($meta_id, int $object_id, $meta_key = '', $meta_value = ''): void
     {
         if (get_post_type($object_id) !== self::POST_TYPE) {
             return;


### PR DESCRIPTION
## Summary
- change the cache flush callbacks in ArtistsDirectory to be public so WordPress hooks can call them
- make the corresponding cache flush callbacks public in OrgsDirectory

## Testing
- not run (manual WordPress interaction required)

------
https://chatgpt.com/codex/tasks/task_e_68e35ca4a600832eb2d0e93e7cb6274b