### PR TITLE
Update organization directory slug default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ phpcs for coding standards (composer run lint)
 Both directory shortcodes honour the `per_page` attribute and use query
 parameters for deep filtering (e.g. `?s=sculpture` or `?tax[artist_specialty][]=ceramics`).
 When permalinks are enabled, letters map to friendly URLs such as
-`/artists/letter/B/` and `/galleries/letter/all/`. Each directory renders a
+`/artists/letter/B/` and `/organizations/letter/all/`. Legacy installs can
+continue using `/galleries/letter/{letter}/` by filtering the
+`ap_galleries_directory_base` hook. Each directory renders a
 canonical `<link>` tag pointing to the active letter URL (including search and
 taxonomy query strings) and caches rendered output for six hours. Caches flush
 when relevant posts, taxonomies, or metadata change.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -75,8 +75,10 @@ Shortcodes:
 Key behaviour:
 
 - Friendly letter routes are registered for each directory. Out of the box the
-  plugin expects pages at `/artists/letter/{letter}/` and `/galleries/letter/{letter}/`
-  (e.g. `/artists/letter/B/` or `/galleries/letter/all/`). Query parameters such as
+  plugin expects pages at `/artists/letter/{letter}/` and `/organizations/letter/{letter}/`
+  (e.g. `/artists/letter/B/` or `/organizations/letter/all/`). Legacy installs can
+  continue using the `/galleries/letter/{letter}/` structure by filtering the
+  `ap_galleries_directory_base` hook. Query parameters such as
   `?s=sculpture` or `?tax[artist_specialty][]=ceramics` continue to work for search and
   taxonomy filtering when permalinks are disabled.
 - Every render outputs a canonical `<link>` tag for the active letter URL,

--- a/src/Core/Rewrites.php
+++ b/src/Core/Rewrites.php
@@ -162,7 +162,7 @@ class Rewrites
      */
     public static function get_directory_base_slug(string $type): string
     {
-        $default = $type === 'artists' ? 'artists' : 'galleries';
+        $default = $type === 'artists' ? 'artists' : 'organizations';
         $slug    = apply_filters('ap_' . $type . '_directory_base', $default);
 
         return trim((string) $slug, '/');

--- a/tests/Core/RewritesTest.php
+++ b/tests/Core/RewritesTest.php
@@ -68,7 +68,7 @@ class RewritesTest extends WP_UnitTestCase
         $this->assertNotNull($artist_url);
         $this->assertSame(gmdate('c', strtotime($artist_latest . ' UTC')), (string) $artist_url->lastmod);
 
-        $gallery_url = $this->find_url_node($xml, home_url('/galleries/letter/B/'));
+        $gallery_url = $this->find_url_node($xml, home_url('/organizations/letter/B/'));
         $this->assertNotNull($gallery_url);
         $this->assertSame(gmdate('c', strtotime($gallery_latest . ' UTC')), (string) $gallery_url->lastmod);
     }


### PR DESCRIPTION
## Summary
- default the organization directory slug to `organizations` while preserving the `ap_galleries_directory_base` filter
- update rewrite expectations and documentation to reference the new `/organizations/letter/...` path
- adjust the rewrite unit test to look for the organizations sitemap entry

## Testing
- ⚠️ `vendor/bin/phpunit --testsuite core` *(fails: phpunit not installed; composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3667810b0832e8d45c071cbbc821f