### PR TITLE
Guard directory tax filters

### DIFF
--- a/src/Frontend/ArtistsDirectory.php
+++ b/src/Frontend/ArtistsDirectory.php
@@ -555,6 +555,13 @@ class ArtistsDirectory
     private static function parse_tax_filters(): array
     {
         $filters = [];
+
+        $valid_taxonomies = get_object_taxonomies(self::POST_TYPE, 'names');
+        if (!is_array($valid_taxonomies)) {
+            $valid_taxonomies = [];
+        }
+        $valid_taxonomies = array_filter(array_map('sanitize_key', $valid_taxonomies));
+        $valid_taxonomies = array_fill_keys($valid_taxonomies, true);
         if (!isset($_GET['tax'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
             return $filters;
         }
@@ -566,7 +573,7 @@ class ArtistsDirectory
 
         foreach ($raw as $taxonomy => $terms) {
             $taxonomy = sanitize_key($taxonomy);
-            if ('' === $taxonomy) {
+            if ('' === $taxonomy || !isset($valid_taxonomies[$taxonomy])) {
                 continue;
             }
 

--- a/src/Frontend/OrgsDirectory.php
+++ b/src/Frontend/OrgsDirectory.php
@@ -561,6 +561,13 @@ class OrgsDirectory
     private static function parse_tax_filters(): array
     {
         $filters = [];
+
+        $valid_taxonomies = get_object_taxonomies(self::POST_TYPE, 'names');
+        if (!is_array($valid_taxonomies)) {
+            $valid_taxonomies = [];
+        }
+        $valid_taxonomies = array_filter(array_map('sanitize_key', $valid_taxonomies));
+        $valid_taxonomies = array_fill_keys($valid_taxonomies, true);
         if (!isset($_GET['tax'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
             return $filters;
         }
@@ -572,7 +579,7 @@ class OrgsDirectory
 
         foreach ($raw as $taxonomy => $terms) {
             $taxonomy = sanitize_key($taxonomy);
-            if ('' === $taxonomy) {
+            if ('' === $taxonomy || !isset($valid_taxonomies[$taxonomy])) {
                 continue;
             }
 

--- a/tests/Frontend/ArtistsDirectoryTest.php
+++ b/tests/Frontend/ArtistsDirectoryTest.php
@@ -79,6 +79,32 @@ class ArtistsDirectoryTest extends WP_UnitTestCase
         $this->assertStringNotContainsString('Alice Aardvark', $output);
     }
 
+    public function test_taxonomy_filter_ignores_unregistered_taxonomies(): void
+    {
+        self::factory()->term->create([
+            'taxonomy' => 'artist_specialty',
+            'slug'     => 'painter',
+            'name'     => 'Painter',
+        ]);
+
+        $_GET['tax'] = [
+            'artist_specialty' => ['painter'],
+            'category'         => ['news'],
+        ];
+
+        $reflection = new \ReflectionClass(ArtistsDirectory::class);
+        $method = $reflection->getMethod('parse_tax_filters');
+        $method->setAccessible(true);
+
+        $filters = $method->invoke(null);
+
+        unset($_GET['tax']);
+
+        $this->assertArrayHasKey('artist_specialty', $filters);
+        $this->assertSame(['painter'], $filters['artist_specialty']);
+        $this->assertArrayNotHasKey('category', $filters);
+    }
+
     private function resetDirectoryState(): void
     {
         global $wpdb;

--- a/tests/Frontend/OrgsDirectoryTest.php
+++ b/tests/Frontend/OrgsDirectoryTest.php
@@ -85,6 +85,32 @@ class OrgsDirectoryTest extends WP_UnitTestCase
         $this->assertStringNotContainsString('Beta Collective', $output);
     }
 
+    public function test_taxonomy_filter_skips_unregistered_taxonomies(): void
+    {
+        self::factory()->term->create([
+            'taxonomy' => 'organization_category',
+            'slug'     => 'music',
+            'name'     => 'Music',
+        ]);
+
+        $_GET['tax'] = [
+            'organization_category' => ['music'],
+            'post_tag'              => ['featured'],
+        ];
+
+        $reflection = new \ReflectionClass(OrgsDirectory::class);
+        $method = $reflection->getMethod('parse_tax_filters');
+        $method->setAccessible(true);
+
+        $filters = $method->invoke(null);
+
+        unset($_GET['tax']);
+
+        $this->assertArrayHasKey('organization_category', $filters);
+        $this->assertSame(['music'], $filters['organization_category']);
+        $this->assertArrayNotHasKey('post_tag', $filters);
+    }
+
     public function test_pagination_respects_paged_query(): void
     {
         $first = self::factory()->post->create([


### PR DESCRIPTION
## Summary
- reject taxonomy filters that are not registered on the orgs and artists directories
- keep valid taxonomies while sanitizing GET parameters for both directories
- cover the new guardrails with unit tests exercising valid and unrelated taxonomies

## Testing
- ⚠️ `vendor/bin/phpunit --testsuite frontend` *(fails: composer install requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e36775da24832e8d4c0736f082ab87