### PR TITLE
Improve events REST API sanitization, caching, and recurrence expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,17 +102,10 @@ jobs:
       - name: Prepare test database
         run: mysql -h "$DB_HOST" -u"$DB_USER" -p"$DB_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
-      - name: Run PHPUnit tests
-        run: |
-          mkdir -p build/logs
-          vendor/bin/phpunit --configuration phpunit.xml.dist --log-junit "build/logs/phpunit-${{ matrix.php-version }}-${{ matrix.wp-version }}.xml"
-
-      - name: Upload PHPUnit logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: phpunit-${{ matrix.php-version }}-${{ matrix.wp-version }}
-          path: build/logs/phpunit-${{ matrix.php-version }}-${{ matrix.wp-version }}.xml
+      - name: PHPUnit
+        env:
+          WP_PHPUNIT__DIR: vendor/wp-phpunit/wp-phpunit
+        run: vendor/bin/phpunit --testdox --colors=always
 
   i18n-check:
     name: Internationalization catalog

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Run the test suite with:
 vendor/bin/phpunit --testdox
 ```
 
+Tests also run automatically in CI via GitHub Actions, which installs Composer
+dependencies (`composer install --no-interaction --prefer-dist`) and executes
+`vendor/bin/phpunit --testdox --colors=always` with `WP_PHPUNIT__DIR` pointing to
+`vendor/wp-phpunit/wp-phpunit`. Build Composer vendors on CI or a development
+machine and deploy the generated `vendor/` directory—avoid running Composer or
+PHPUnit on production servers.
+
 ### WP-CLI utilities
 
 Backfill cached directory letter metadata for artists or organizations. This keeps

--- a/src/Core/PostTypeRegistrar.php
+++ b/src/Core/PostTypeRegistrar.php
@@ -4,6 +4,15 @@ namespace ArtPulse\Core;
 
 class PostTypeRegistrar
 {
+    public const EVENT_POST_TYPE = 'artpulse_event';
+
+    public const EVENT_TAXONOMY = 'artpulse_event_type';
+
+    /**
+     * @var string[]
+     */
+    public const EVENT_TAXONOMIES = [self::EVENT_TAXONOMY];
+
     public static function register()
     {
         // Base config shared by all CPTs
@@ -19,10 +28,10 @@ class PostTypeRegistrar
 
         // Register CPTs
         $post_types = [
-            'artpulse_event'   => [
+            self::EVENT_POST_TYPE   => [
                 'label'           => __('Events', 'artpulse'),
                 'rewrite'         => ['slug' => 'events'],
-                'taxonomies'      => ['artpulse_event_type'],
+                'taxonomies'      => self::EVENT_TAXONOMIES,
             ],
             'artpulse_artist'  => [
                 'label'           => __('Artists', 'artpulse'),
@@ -67,8 +76,8 @@ class PostTypeRegistrar
 
         // Taxonomies
         register_taxonomy(
-            'artpulse_event_type',
-            'artpulse_event',
+            self::EVENT_TAXONOMY,
+            self::EVENT_POST_TYPE,
             [
                 'label'        => __('Event Types', 'artpulse'),
                 'public'       => true,
@@ -94,7 +103,7 @@ class PostTypeRegistrar
     private static function register_meta_boxes()
     {
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_date',
             [
                 'show_in_rest' => true,
@@ -104,7 +113,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_location',
             [
                 'show_in_rest' => true,
@@ -114,7 +123,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_start',
             [
                 'show_in_rest' => true,
@@ -124,7 +133,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_end',
             [
                 'show_in_rest' => true,
@@ -134,7 +143,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_all_day',
             [
                 'show_in_rest' => true,
@@ -145,7 +154,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_timezone',
             [
                 'show_in_rest' => true,
@@ -155,7 +164,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_cost',
             [
                 'show_in_rest' => true,
@@ -165,7 +174,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_recurrence',
             [
                 'show_in_rest' => true,
@@ -175,7 +184,7 @@ class PostTypeRegistrar
         );
 
         register_post_meta(
-            'artpulse_event',
+            self::EVENT_POST_TYPE,
             '_ap_event_organization',
             [
                 'show_in_rest' => true,

--- a/src/Integration/Recurrence/RecurrenceExpander.php
+++ b/src/Integration/Recurrence/RecurrenceExpander.php
@@ -1,0 +1,435 @@
+<?php
+
+namespace ArtPulse\Integration\Recurrence;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use function wp_parse_list;
+
+class RecurrenceExpander
+{
+    public const MAX_INSTANCES = 1000;
+
+    /**
+     * @param array<string, mixed> $event
+     * @return array{occurrences: array<int, array<string, mixed>>, truncated: bool}
+     */
+    public static function expand(array $event, ?DateTimeImmutable $rangeStart, ?DateTimeImmutable $rangeEnd): array
+    {
+        $startUtc = self::parseUtc($event['startUtc'] ?? $event['start'] ?? null);
+        if (!$startUtc) {
+            return ['occurrences' => [], 'truncated' => false];
+        }
+
+        $timezone = self::resolveTimezone($event['timezone'] ?? null);
+        $endUtc   = self::parseUtc($event['endUtc'] ?? $event['end'] ?? null);
+
+        if (!$endUtc) {
+            $endUtc = self::fallbackEnd($startUtc, !empty($event['allDay']));
+        }
+
+        $baseStartLocal = $startUtc->setTimezone($timezone);
+        $baseEndLocal   = $endUtc->setTimezone($timezone);
+        $durationSeconds = max(0, $baseEndLocal->getTimestamp() - $baseStartLocal->getTimestamp());
+        if (0 === $durationSeconds) {
+            $durationSeconds = !empty($event['allDay']) ? DAY_IN_SECONDS : HOUR_IN_SECONDS;
+        }
+
+        $occurrenceSet = self::buildOccurrenceSet(
+            $event['recurrence'] ?? null,
+            $baseStartLocal,
+            $timezone,
+            $rangeStart,
+            $rangeEnd
+        );
+
+        $occurrences      = [];
+        $truncated        = false;
+        $rangeStartUtc    = $rangeStart;
+        $rangeEndUtc      = $rangeEnd;
+        $totalOccurrences = 0;
+
+        foreach ($occurrenceSet['instances'] as $localStart) {
+            $localEnd = $localStart->modify('+' . $durationSeconds . ' seconds');
+            $start    = $localStart->setTimezone(new DateTimeZone('UTC'));
+            $end      = $localEnd->setTimezone(new DateTimeZone('UTC'));
+
+            if (!self::overlaps($start, $end, $rangeStartUtc, $rangeEndUtc)) {
+                continue;
+            }
+
+            $occurrences[] = [
+                'id'         => $event['id'] ?? null,
+                'title'      => $event['title'] ?? '',
+                'allDay'     => !empty($event['allDay']),
+                'timezone'   => $timezone->getName(),
+                'location'   => $event['location'] ?? '',
+                'cost'       => $event['cost'] ?? '',
+                'url'        => $event['url'] ?? '',
+                'favorite'   => !empty($event['favorite']),
+                'start'      => $start->format(DateTimeInterface::ATOM),
+                'end'        => $end->format(DateTimeInterface::ATOM),
+                'startLocal' => $localStart->format(DateTimeInterface::ATOM),
+                'endLocal'   => $localEnd->format(DateTimeInterface::ATOM),
+            ];
+
+            $totalOccurrences++;
+
+            if ($totalOccurrences >= self::MAX_INSTANCES) {
+                $truncated = true;
+                break;
+            }
+        }
+
+        if ($occurrenceSet['limited']) {
+            $truncated = true;
+        }
+
+        return [
+            'occurrences' => array_values($occurrences),
+            'truncated'   => $truncated,
+        ];
+    }
+
+    /**
+     * @param null|string|array<mixed> $recurrence
+     * @return array{instances: array<int, DateTimeImmutable>, limited: bool}
+     */
+    private static function buildOccurrenceSet($recurrence, DateTimeImmutable $baseStartLocal, DateTimeZone $timezone, ?DateTimeImmutable $rangeStart, ?DateTimeImmutable $rangeEnd): array
+    {
+        $starts  = [$baseStartLocal->format(DateTimeInterface::ATOM) => $baseStartLocal];
+        $limited = false;
+
+        $definition = self::parseRecurrenceDefinition($recurrence);
+
+        if ($definition['rrule']) {
+            $rule = self::parseRrule($definition['rrule'], $timezone);
+            if ($rule) {
+                $current      = $baseStartLocal;
+                $occurrenceNo = 1; // base occurrence counted.
+                $iterations   = 0;
+                $rangeLimit   = $rangeEnd ? $rangeEnd->setTimezone($timezone)->modify('+1 month') : null;
+
+                while (true) {
+                    if ($rule['count'] && $occurrenceNo >= $rule['count']) {
+                        break;
+                    }
+
+                    $next = self::advance($current, $rule['freq'], $rule['interval']);
+                    if (!$next) {
+                        break;
+                    }
+
+                    $current = $next;
+
+                    if ($rule['until'] && $current > $rule['until']->setTimezone($timezone)) {
+                        break;
+                    }
+
+                    if ($rangeLimit && $current > $rangeLimit) {
+                        $limited = true;
+                        break;
+                    }
+
+                    $starts[$current->format(DateTimeInterface::ATOM)] = $current;
+                    $occurrenceNo++;
+                    $iterations++;
+
+                    if ($iterations >= self::MAX_INSTANCES * 5) {
+                        $limited = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ($definition['rdates']) {
+            foreach ($definition['rdates'] as $rdateString) {
+                $rdate = self::parseRdate($rdateString, $timezone, $baseStartLocal);
+                if ($rdate) {
+                    $starts[$rdate->format(DateTimeInterface::ATOM)] = $rdate;
+                }
+            }
+        }
+
+        ksort($starts);
+
+        return [
+            'instances' => array_values($starts),
+            'limited'   => $limited,
+        ];
+    }
+
+    private static function overlaps(DateTimeImmutable $start, DateTimeImmutable $end, ?DateTimeImmutable $rangeStart, ?DateTimeImmutable $rangeEnd): bool
+    {
+        if ($rangeStart && $end < $rangeStart) {
+            return false;
+        }
+
+        if ($rangeEnd && $start > $rangeEnd) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function parseUtc($value): ?DateTimeImmutable
+    {
+        if ($value instanceof DateTimeImmutable) {
+            return $value->setTimezone(new DateTimeZone('UTC'));
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ('' === $value) {
+            return null;
+        }
+
+        try {
+            $date = new DateTimeImmutable($value);
+
+            return $date->setTimezone(new DateTimeZone('UTC'));
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    private static function resolveTimezone($timezone): DateTimeZone
+    {
+        if (is_string($timezone) && '' !== $timezone) {
+            try {
+                return new DateTimeZone($timezone);
+            } catch (\Exception $e) {
+                // Fall through to defaults.
+            }
+        }
+
+        if (function_exists('wp_timezone')) {
+            $wpTimezone = \wp_timezone();
+            if ($wpTimezone instanceof DateTimeZone) {
+                return $wpTimezone;
+            }
+        }
+
+        return new DateTimeZone('UTC');
+    }
+
+    private static function fallbackEnd(DateTimeImmutable $start, bool $allDay): DateTimeImmutable
+    {
+        try {
+            return $start->add(new DateInterval($allDay ? 'P1D' : 'PT1H'));
+        } catch (\Exception $e) {
+            return $start;
+        }
+    }
+
+    /**
+     * @return array{rrule: ?string, rdates: array<int, string>}
+     */
+    private static function parseRecurrenceDefinition($recurrence): array
+    {
+        $rrule  = null;
+        $rdates = [];
+
+        if (is_string($recurrence)) {
+            $lines = preg_split('/[\r\n]+/', trim($recurrence)) ?: [];
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ('' === $line) {
+                    continue;
+                }
+
+                if (str_starts_with($line, 'RRULE')) {
+                    $rrule = self::valueAfterColon($line);
+                } elseif (str_starts_with($line, 'RDATE')) {
+                    $rdates = array_merge($rdates, self::extractListAfterColon($line));
+                }
+            }
+        } elseif (is_array($recurrence)) {
+            $rruleCandidate = $recurrence['rrule'] ?? $recurrence['RRULE'] ?? null;
+            if (is_array($rruleCandidate)) {
+                $rruleCandidate = implode("\n", array_map('strval', $rruleCandidate));
+            }
+            if (is_string($rruleCandidate) && '' !== trim($rruleCandidate)) {
+                $rrule = trim($rruleCandidate);
+            }
+
+            $rdateCandidate = $recurrence['rdate'] ?? $recurrence['RDATE'] ?? null;
+            if (is_string($rdateCandidate)) {
+                $rdates = array_merge($rdates, self::extractListAfterColon($rdateCandidate));
+            } elseif (is_array($rdateCandidate)) {
+                foreach ($rdateCandidate as $candidate) {
+                    if (is_string($candidate)) {
+                        $rdates = array_merge($rdates, self::extractListAfterColon($candidate));
+                    }
+                }
+            }
+        }
+
+        return [
+            'rrule'  => $rrule,
+            'rdates' => array_values(array_filter(array_map('trim', $rdates))),
+        ];
+    }
+
+    private static function valueAfterColon(string $value): string
+    {
+        $parts = explode(':', $value, 2);
+
+        return isset($parts[1]) ? trim($parts[1]) : trim($parts[0]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function extractListAfterColon(string $value): array
+    {
+        $list = self::valueAfterColon($value);
+        $items = array_map('trim', explode(',', $list));
+
+        return array_filter($items, static fn($item) => '' !== $item);
+    }
+
+    /**
+     * @return array{freq: string, interval: int, count: ?int, until: ?DateTimeImmutable}|null
+     */
+    private static function parseRrule(?string $rule, DateTimeZone $timezone): ?array
+    {
+        if (null === $rule || '' === trim($rule)) {
+            return null;
+        }
+
+        if (str_starts_with($rule, 'RRULE:')) {
+            $rule = substr($rule, 6);
+        }
+
+        $parts = wp_parse_list($rule);
+        $data  = [
+            'freq'     => 'DAILY',
+            'interval' => 1,
+            'count'    => null,
+            'until'    => null,
+        ];
+
+        foreach ($parts as $part) {
+            if (!str_contains($part, '=')) {
+                continue;
+            }
+
+            [$key, $value] = array_map('trim', explode('=', $part, 2));
+            $keyUpper = strtoupper($key);
+
+            switch ($keyUpper) {
+                case 'FREQ':
+                    $allowed = ['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'];
+                    $valueUpper = strtoupper($value);
+                    if (in_array($valueUpper, $allowed, true)) {
+                        $data['freq'] = $valueUpper;
+                    }
+                    break;
+                case 'INTERVAL':
+                    $interval = max(1, (int) $value);
+                    $data['interval'] = $interval;
+                    break;
+                case 'COUNT':
+                    $count = (int) $value;
+                    $data['count'] = $count > 0 ? $count : null;
+                    break;
+                case 'UNTIL':
+                    $until = self::parseUntil($value, $timezone);
+                    if ($until) {
+                        $data['until'] = $until;
+                    }
+                    break;
+            }
+        }
+
+        return $data;
+    }
+
+    private static function parseUntil(string $value, DateTimeZone $timezone): ?DateTimeImmutable
+    {
+        $value = trim($value);
+        if ('' === $value) {
+            return null;
+        }
+
+        try {
+            if (str_ends_with($value, 'Z')) {
+                return new DateTimeImmutable($value, new DateTimeZone('UTC'));
+            }
+
+            return new DateTimeImmutable($value, $timezone);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    private static function advance(DateTimeImmutable $date, string $frequency, int $interval): ?DateTimeImmutable
+    {
+        $frequency = strtoupper($frequency);
+
+        try {
+            switch ($frequency) {
+                case 'DAILY':
+                    return $date->add(new DateInterval('P' . $interval . 'D'));
+                case 'WEEKLY':
+                    return $date->add(new DateInterval('P' . $interval . 'W'));
+                case 'MONTHLY':
+                    return $date->add(new DateInterval('P' . $interval . 'M'));
+                case 'YEARLY':
+                    return $date->add(new DateInterval('P' . $interval . 'Y'));
+                default:
+                    return $date->add(new DateInterval('P' . $interval . 'D'));
+            }
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    private static function parseRdate(string $value, DateTimeZone $timezone, DateTimeImmutable $baseStartLocal): ?DateTimeImmutable
+    {
+        $value = trim($value);
+        if ('' === $value) {
+            return null;
+        }
+
+        if (str_contains($value, ':')) {
+            $value = self::valueAfterColon($value);
+        }
+
+        try {
+            if (preg_match('/^\d{8}$/', $value)) {
+                $date = DateTimeImmutable::createFromFormat('Ymd H:i:s', $value . ' ' . $baseStartLocal->format('H:i:s'), $timezone);
+
+                if ($date instanceof DateTimeImmutable) {
+                    return $date;
+                }
+            }
+
+            if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+                $date = new DateTimeImmutable($value, $timezone);
+
+                return $date->setTime(
+                    (int) $baseStartLocal->format('H'),
+                    (int) $baseStartLocal->format('i'),
+                    (int) $baseStartLocal->format('s')
+                );
+            }
+
+            if (str_ends_with($value, 'Z')) {
+                return (new DateTimeImmutable($value, new DateTimeZone('UTC')))->setTimezone($timezone);
+            }
+
+            return new DateTimeImmutable($value, $timezone);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}
+

--- a/src/Rest/EventsController.php
+++ b/src/Rest/EventsController.php
@@ -3,7 +3,8 @@
 namespace ArtPulse\Rest;
 
 use ArtPulse\Community\FavoritesManager;
-use DateInterval;
+use ArtPulse\Core\PostTypeRegistrar;
+use ArtPulse\Integration\Recurrence\RecurrenceExpander;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
@@ -20,7 +21,7 @@ class EventsController
     public static function boot(): void
     {
         add_action('rest_api_init', [self::class, 'register']);
-        add_action('save_post_artpulse_event', [self::class, 'purge_cache']);
+        add_action('save_post_' . PostTypeRegistrar::EVENT_POST_TYPE, [self::class, 'purge_cache']);
         add_action('deleted_post', [self::class, 'purge_cache']);
         add_action('set_object_terms', [self::class, 'purge_cache']);
     }
@@ -57,15 +58,27 @@ class EventsController
     public static function get_events(WP_REST_Request $request): WP_REST_Response
     {
         $params = self::normalize_request_params($request);
-        $result = self::fetch_events($params);
+        $result = self::fetch_events($params, true);
 
-        $response = rest_ensure_response([
+        $payload = [
             'events'     => $result['events'],
             'pagination' => $result['pagination'],
-        ]);
+            'truncated'  => $result['truncated'],
+        ];
 
+        $etag = self::build_etag($payload);
+        if (self::is_not_modified($request, $etag)) {
+            return new WP_REST_Response(null, 304, ['ETag' => $etag]);
+        }
+
+        $response = rest_ensure_response($payload);
+        $response->header('ETag', $etag);
         $response->header('X-WP-Total', (string) $result['pagination']['total']);
         $response->header('X-WP-TotalPages', (string) $result['pagination']['total_pages']);
+
+        if (!empty($result['truncated'])) {
+            $response->header('X-ArtPulse-Truncated', '1');
+        }
 
         return $response;
     }
@@ -75,23 +88,44 @@ class EventsController
         $id = (int) $request->get_param('id');
         $post = get_post($id);
 
-        if (!$post instanceof WP_Post || 'artpulse_event' !== $post->post_type || 'publish' !== $post->post_status) {
+        if (!$post instanceof WP_Post || PostTypeRegistrar::EVENT_POST_TYPE !== $post->post_type || 'publish' !== $post->post_status) {
             return new WP_Error('not_found', __('Event not found.', 'artpulse-management'), ['status' => 404]);
         }
 
         $event = self::prepare_event($post->ID);
-        $event['occurrences'] = self::expand_occurrences($event, null, null);
+        $expansion = self::expand_occurrences($event, null, null);
+        $event['occurrences'] = $expansion['occurrences'];
+        $event['occurrencesTruncated'] = $expansion['truncated'];
 
         return rest_ensure_response($event);
     }
 
     public static function get_ics(WP_REST_Request $request): WP_REST_Response
     {
-        $params = self::normalize_request_params($request);
-        $result = self::fetch_events($params, false);
+        $params      = self::normalize_request_params($request);
+        $fingerprint = $params['cache_fingerprint'] ?? [];
 
-        $ics = self::generate_ics($result['events']);
+        $fingerprint['user'] = !empty($params['favorites']) ? (int) get_current_user_id() : 0;
+        $cache_key           = self::get_cache_key($fingerprint, false, 'events.ics');
+
+        $ics = self::cache_get($cache_key);
+        if (false === $ics) {
+            $result = self::fetch_events($params, false);
+            $ics    = self::generate_ics($result['events']);
+            self::cache_set($cache_key, $ics);
+        }
+
+        $etag = self::build_etag($ics);
+        if (self::is_not_modified($request, $etag)) {
+            return new WP_REST_Response(null, 304, [
+                'ETag'               => $etag,
+                'Content-Type'       => 'text/calendar; charset=utf-8',
+                'Content-Disposition' => 'attachment; filename="events.ics"',
+            ]);
+        }
+
         $response = new WP_REST_Response($ics);
+        $response->header('ETag', $etag);
         $response->header('Content-Type', 'text/calendar; charset=utf-8');
         $response->header('Content-Disposition', 'attachment; filename="events.ics"');
 
@@ -108,64 +142,36 @@ class EventsController
      */
     public static function fetch_events(array $args = [], bool $apply_pagination = true): array
     {
-        $defaults = [
-            'start'      => null,
-            'end'        => null,
-            'category'   => [],
-            'org'        => null,
-            'favorites'  => false,
-            'per_page'   => 20,
-            'page'       => 1,
-            'orderby'    => 'start',
-            'order'      => 'ASC',
-            'event_id'   => null,
-        ];
+        $normalized = self::ensure_normalized_args($args);
+        $range_start = $normalized['range_start'];
+        $range_end   = $normalized['range_end'];
 
-        $args = array_merge($defaults, $args);
+        $fingerprint = $normalized['cache_fingerprint'];
+        $current_user_id = get_current_user_id();
+        $fingerprint['user'] = $normalized['favorites'] ? (int) $current_user_id : 0;
 
-        $cache_key = self::get_cache_key($args, $apply_pagination);
-        $cached    = wp_cache_get($cache_key, 'artpulse_events');
+        $cache_key = self::get_cache_key($fingerprint, $apply_pagination);
+        $cached    = self::cache_get($cache_key);
         if (false !== $cached) {
             return $cached;
         }
 
-        $range_start = $args['start'] instanceof DateTimeImmutable ? $args['start'] : self::parse_date($args['start']);
-        $range_end   = $args['end'] instanceof DateTimeImmutable ? $args['end'] : self::parse_date($args['end']);
-
         $query_args = [
-            'post_type'      => 'artpulse_event',
+            'post_type'      => PostTypeRegistrar::EVENT_POST_TYPE,
             'post_status'    => 'publish',
             'posts_per_page' => -1,
             'no_found_rows'  => true,
             'fields'         => 'ids',
         ];
 
-        if (!empty($args['category'])) {
-            $slugs = array_map('sanitize_title', (array) $args['category']);
-            $query_args['tax_query'] = [
-                [
-                    'taxonomy' => 'artpulse_event_type',
-                    'field'    => 'slug',
-                    'terms'    => $slugs,
-                ],
-            ];
-        }
-
-        if (!empty($args['org'])) {
-            $query_args['meta_query'][] = [
-                'key'   => '_ap_event_organization',
-                'value' => (int) $args['org'],
-            ];
-        }
-
-        if (!empty($args['event_id'])) {
-            $query_args['post__in'] = [(int) $args['event_id']];
+        if (!empty($normalized['taxonomy_query'])) {
+            $query_args['tax_query'] = $normalized['taxonomy_query'];
         }
 
         $query = new WP_Query($query_args);
 
-        $events = [];
-        $current_user_id = get_current_user_id();
+        $events           = [];
+        $truncated_global = false;
 
         foreach ($query->posts as $post_id) {
             $event = self::prepare_event((int) $post_id, $current_user_id);
@@ -173,39 +179,40 @@ class EventsController
                 continue;
             }
 
-            $occurrences = self::expand_occurrences($event, $range_start, $range_end);
-            if (empty($occurrences)) {
+            $expansion = self::expand_occurrences($event, $range_start, $range_end);
+            if (empty($expansion['occurrences'])) {
                 continue;
             }
 
-            foreach ($occurrences as $index => $occurrence) {
-                if ($args['favorites'] && empty($occurrence['favorite'])) {
+            if (!empty($expansion['truncated'])) {
+                $truncated_global = true;
+            }
+
+            foreach ($expansion['occurrences'] as $index => $occurrence) {
+                if ($normalized['favorites'] && empty($occurrence['favorite'])) {
                     continue;
                 }
 
                 $events[] = $occurrence + [
-                    'occurrence'  => $index,
-                    'categories'  => $event['categories'],
-                    'categoryNames' => $event['categoryNames'],
-                    'organization' => $event['organization'],
-                    'organizationName' => $event['organizationName'],
-                    'thumbnail'   => $event['thumbnail'],
-                    'excerpt'     => $event['excerpt'],
-                    'schema'      => $event['schema'],
-                    'description' => $event['excerpt'],
+                    'occurrence'        => $index,
+                    'categories'        => $event['categories'],
+                    'categoryNames'     => $event['categoryNames'],
+                    'organization'      => $event['organization'],
+                    'organizationName'  => $event['organizationName'],
+                    'thumbnail'         => $event['thumbnail'],
+                    'excerpt'           => $event['excerpt'],
+                    'schema'            => $event['schema'],
+                    'description'       => $event['excerpt'],
                 ];
             }
         }
 
-        usort($events, static function (array $a, array $b) use ($args): int {
-            $direction = 'DESC' === strtoupper((string) $args['order']) ? -1 : 1;
-            return $direction * strcmp((string) ($a[$args['orderby']] ?? ''), (string) ($b[$args['orderby']] ?? ''));
-        });
+        $events = self::sort_events($events, $normalized['orderby'], $normalized['order']);
 
-        $total        = count($events);
-        $per_page     = max(1, (int) $args['per_page']);
-        $page         = max(1, (int) $args['page']);
-        $total_pages  = (int) max(1, ceil($total / $per_page));
+        $total    = count($events);
+        $per_page = $normalized['per_page'];
+        $page     = $normalized['page'];
+        $total_pages = (int) max(1, ceil($total / $per_page));
         $paged_events = $events;
 
         if ($apply_pagination) {
@@ -221,72 +228,396 @@ class EventsController
                 'per_page'    => $per_page,
                 'current'     => $page,
             ],
+            'truncated'  => $truncated_global,
         ];
 
-        wp_cache_set($cache_key, $result, 'artpulse_events', HOUR_IN_SECONDS);
+        self::cache_set($cache_key, $result);
 
         return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<string, mixed>
+     */
+    private static function ensure_normalized_args(array $args): array
+    {
+        if (!empty($args['_normalized'])) {
+            return $args;
+        }
+
+        return self::normalize_args($args);
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalize_args(array $args): array
+    {
+        $timezone    = \wp_timezone();
+        $start_input = $args['start'] ?? null;
+        $end_input   = $args['end'] ?? null;
+
+        [$start_utc, $end_utc] = self::normalize_date_range($start_input, $end_input, $timezone);
+
+        $per_page = isset($args['per_page']) ? (int) $args['per_page'] : 20;
+        $per_page = max(1, $per_page ?: 20);
+        $per_page = min($per_page, 100);
+
+        $page = isset($args['page']) ? (int) $args['page'] : 1;
+        $page = max(1, $page);
+
+        $orderby = is_string($args['orderby'] ?? '') ? strtolower((string) $args['orderby']) : '';
+        $allowed_orderby = ['event_start', 'title'];
+        if (!in_array($orderby, $allowed_orderby, true)) {
+            $orderby = 'event_start';
+        }
+
+        $order = strtoupper(is_string($args['order'] ?? '') ? (string) $args['order'] : '');
+        $order = 'DESC' === $order ? 'DESC' : 'ASC';
+
+        $favorites = self::to_bool($args['favorites'] ?? false);
+
+        $taxonomy_filters = self::normalize_taxonomy_filters($args['taxonomy'] ?? []);
+
+        $cache_fingerprint = [
+            'start'     => $start_utc->format(DateTimeInterface::ATOM),
+            'end'       => $end_utc->format(DateTimeInterface::ATOM),
+            'page'      => $page,
+            'per_page'  => $per_page,
+            'orderby'   => $orderby,
+            'order'     => $order,
+            'favorites' => $favorites ? 1 : 0,
+            'taxonomy'  => $taxonomy_filters['fingerprint'],
+        ];
+
+        return [
+            '_normalized'       => true,
+            'range_start'       => $start_utc,
+            'range_end'         => $end_utc,
+            'per_page'          => $per_page,
+            'page'              => $page,
+            'orderby'           => $orderby,
+            'order'             => $order,
+            'favorites'         => $favorites,
+            'taxonomy_query'    => $taxonomy_filters['query'],
+            'cache_fingerprint' => $cache_fingerprint,
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array{query: array<int|string, array<string, mixed>>, fingerprint: array<int, array{taxonomy: string, field: string, terms: array<int, int|string>}>}
+     */
+    private static function normalize_taxonomy_filters($value): array
+    {
+        $allowed = get_object_taxonomies(PostTypeRegistrar::EVENT_POST_TYPE, 'names');
+        $allowed = is_array($allowed) ? array_map('strval', $allowed) : [];
+
+        $query       = [];
+        $fingerprint = [];
+
+        foreach ((array) $value as $raw_taxonomy => $raw_terms) {
+            $taxonomy = sanitize_key((string) $raw_taxonomy);
+            if ('' === $taxonomy || !in_array($taxonomy, $allowed, true)) {
+                continue;
+            }
+
+            $terms     = is_array($raw_terms) ? $raw_terms : [$raw_terms];
+            $term_ids  = [];
+            $term_slugs = [];
+
+            foreach ($terms as $term) {
+                if (is_int($term) || (is_string($term) && is_numeric($term))) {
+                    $term_id = (int) $term;
+                    if ($term_id > 0) {
+                        $term_ids[] = $term_id;
+                    }
+                    continue;
+                }
+
+                if (is_string($term)) {
+                    $slug = sanitize_title($term);
+                    if ('' !== $slug) {
+                        $term_slugs[] = $slug;
+                    }
+                }
+            }
+
+            if ($term_slugs) {
+                $unique_slugs = array_values(array_unique($term_slugs));
+                $clause = [
+                    'taxonomy' => $taxonomy,
+                    'field'    => 'slug',
+                    'terms'    => $unique_slugs,
+                ];
+                $query[]       = $clause;
+                $fingerprint[] = $clause;
+            }
+
+            if ($term_ids) {
+                $unique_ids = array_values(array_unique($term_ids));
+                $clause = [
+                    'taxonomy' => $taxonomy,
+                    'field'    => 'term_id',
+                    'terms'    => $unique_ids,
+                ];
+                $query[]       = $clause;
+                $fingerprint[] = $clause;
+            }
+        }
+
+        if ($query) {
+            $relation = count($query) > 1 ? ['relation' => 'AND'] : [];
+            if ($relation) {
+                $query = array_merge($relation, $query);
+            }
+        }
+
+        if ($fingerprint) {
+            foreach ($fingerprint as &$entry) {
+                $terms = $entry['terms'];
+                sort($terms);
+                $entry['terms'] = $terms;
+            }
+            unset($entry);
+
+            usort($fingerprint, static function (array $a, array $b): int {
+                $taxonomy_compare = strcmp($a['taxonomy'], $b['taxonomy']);
+                if (0 !== $taxonomy_compare) {
+                    return $taxonomy_compare;
+                }
+
+                $field_compare = strcmp($a['field'], $b['field']);
+                if (0 !== $field_compare) {
+                    return $field_compare;
+                }
+
+                return strcmp(wp_json_encode($a['terms']), wp_json_encode($b['terms']));
+            });
+        }
+
+        return [
+            'query'       => $query,
+            'fingerprint' => $fingerprint,
+        ];
+    }
+
+    /**
+     * @param mixed $start
+     * @param mixed $end
+     *
+     * @return array{0: DateTimeImmutable, 1: DateTimeImmutable}
+     */
+    private static function normalize_date_range($start, $end, DateTimeZone $timezone): array
+    {
+        [$default_start, $default_end] = self::default_month_range($timezone);
+
+        $start_local = self::parse_range_boundary($start, $timezone, false) ?? $default_start;
+        $end_local   = self::parse_range_boundary($end, $timezone, true);
+
+        if (!$end_local) {
+            $end_local = self::default_end_for_start($start_local);
+        }
+
+        if ($end_local < $start_local) {
+            $end_local = $start_local;
+        }
+
+        return [
+            $start_local->setTimezone(new DateTimeZone('UTC')),
+            $end_local->setTimezone(new DateTimeZone('UTC')),
+        ];
+    }
+
+    private static function default_month_range(DateTimeZone $timezone): array
+    {
+        $now = new DateTimeImmutable('now', $timezone);
+        $start = $now->modify('first day of this month')->setTime(0, 0, 0);
+        $end   = $start->modify('last day of this month')->setTime(23, 59, 59);
+
+        return [$start, $end];
+    }
+
+    private static function default_end_for_start(DateTimeImmutable $start): DateTimeImmutable
+    {
+        return $start->modify('last day of this month')->setTime(23, 59, 59);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function parse_range_boundary($value, DateTimeZone $timezone, bool $is_end): ?DateTimeImmutable
+    {
+        if ($value instanceof DateTimeImmutable) {
+            return $value->setTimezone($timezone);
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ('' === $value) {
+            return null;
+        }
+
+        try {
+            if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+                $date = new DateTimeImmutable($value, $timezone);
+                return $is_end ? $date->setTime(23, 59, 59) : $date->setTime(0, 0, 0);
+            }
+
+            $date = new DateTimeImmutable($value, $timezone);
+            if ($is_end && !str_contains($value, 'T') && !str_contains($value, ' ')) {
+                $date = $date->setTime(23, 59, 59);
+            }
+
+            return $date;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $events
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private static function sort_events(array $events, string $orderby, string $order): array
+    {
+        $direction = 'DESC' === strtoupper($order) ? -1 : 1;
+
+        usort($events, static function (array $a, array $b) use ($orderby, $direction): int {
+            if ('title' === $orderby) {
+                return $direction * strcasecmp((string) ($a['title'] ?? ''), (string) ($b['title'] ?? ''));
+            }
+
+            $a_start = isset($a['start']) ? strtotime((string) $a['start']) : 0;
+            $b_start = isset($b['start']) ? strtotime((string) $b['start']) : 0;
+
+            $comparison = $a_start <=> $b_start;
+
+            if (0 === $comparison) {
+                return $direction * strcasecmp((string) ($a['title'] ?? ''), (string) ($b['title'] ?? ''));
+            }
+
+            return $direction * $comparison;
+        });
+
+        return $events;
+    }
+
+    /**
+     * @return mixed
+     */
+    private static function cache_get(string $key)
+    {
+        if (wp_using_ext_object_cache()) {
+            return wp_cache_get($key, 'artpulse_events');
+        }
+
+        $value = get_transient('artpulse_events_' . $key);
+
+        return false === $value ? false : $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function cache_set(string $key, $value): void
+    {
+        if (wp_using_ext_object_cache()) {
+            wp_cache_set($key, $value, 'artpulse_events', HOUR_IN_SECONDS);
+
+            return;
+        }
+
+        set_transient('artpulse_events_' . $key, $value, HOUR_IN_SECONDS);
+    }
+
+    private static function build_etag($payload): string
+    {
+        return '"' . md5(serialize($payload)) . '"';
+    }
+
+    private static function is_not_modified(WP_REST_Request $request, string $etag): bool
+    {
+        $if_none_match = trim((string) $request->get_header('If-None-Match'));
+
+        return '' !== $if_none_match && $if_none_match === $etag;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function to_bool($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value > 0;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return false;
     }
 
     private static function get_collection_args(): array
     {
         return [
             'start'     => [
-                'sanitize_callback' => [self::class, 'sanitize_date'],
+                'sanitize_callback' => [self::class, 'sanitize_date_param'],
             ],
             'end'       => [
-                'sanitize_callback' => [self::class, 'sanitize_date'],
-            ],
-            'category'  => [
-                'sanitize_callback' => [self::class, 'sanitize_array_param'],
-            ],
-            'org'       => [
-                'sanitize_callback' => 'absint',
+                'sanitize_callback' => [self::class, 'sanitize_date_param'],
             ],
             'favorites' => [
-                'sanitize_callback' => static fn($value) => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+                'sanitize_callback' => [self::class, 'sanitize_boolean_param'],
             ],
             'per_page'  => [
-                'sanitize_callback' => 'absint',
-                'default'           => 20,
+                'sanitize_callback' => [self::class, 'sanitize_positive_int'],
             ],
             'page'      => [
-                'sanitize_callback' => 'absint',
-                'default'           => 1,
+                'sanitize_callback' => [self::class, 'sanitize_positive_int'],
             ],
             'orderby'   => [
-                'sanitize_callback' => [self::class, 'sanitize_orderby'],
-                'default'           => 'start',
+                'sanitize_callback' => [self::class, 'sanitize_orderby_param'],
             ],
             'order'     => [
-                'sanitize_callback' => static fn($value) => strtoupper($value) === 'DESC' ? 'DESC' : 'ASC',
-                'default'           => 'ASC',
+                'sanitize_callback' => [self::class, 'sanitize_order_param'],
             ],
-            'event_id'  => [
-                'sanitize_callback' => 'absint',
+            'taxonomy'  => [
+                'sanitize_callback' => [self::class, 'sanitize_taxonomy_param'],
             ],
         ];
     }
 
     private static function normalize_request_params(WP_REST_Request $request): array
     {
-        $category = $request->get_param('category');
-        if (is_string($category)) {
-            $category = [$category];
-        }
-
-        return [
+        $params = [
             'start'     => $request->get_param('start'),
             'end'       => $request->get_param('end'),
-            'category'  => $category ?? [],
-            'org'       => $request->get_param('org'),
-            'favorites' => (bool) $request->get_param('favorites'),
-            'per_page'  => $request->get_param('per_page'),
             'page'      => $request->get_param('page'),
+            'per_page'  => $request->get_param('per_page'),
             'orderby'   => $request->get_param('orderby'),
             'order'     => $request->get_param('order'),
-            'event_id'  => $request->get_param('event_id'),
+            'favorites' => $request->get_param('favorites'),
+            'taxonomy'  => $request->get_param('taxonomy'),
         ];
+
+        return self::normalize_args($params);
     }
 
     private static function prepare_event(int $post_id, int $current_user_id = 0): array
@@ -302,7 +633,7 @@ class EventsController
         }
 
         $timezone = get_post_meta($post_id, '_ap_event_timezone', true);
-        $timezone = $timezone ?: wp_timezone_string();
+        $timezone = $timezone ?: \wp_timezone_string();
         $location = get_post_meta($post_id, '_ap_event_location', true);
         $cost     = get_post_meta($post_id, '_ap_event_cost', true);
         $all_day  = (bool) get_post_meta($post_id, '_ap_event_all_day', true);
@@ -313,12 +644,12 @@ class EventsController
         $thumbnail = $thumb_id ? wp_get_attachment_image_url($thumb_id, 'large') : '';
         $excerpt   = wp_strip_all_tags(get_the_excerpt($post_id));
 
-        $categories = wp_get_post_terms($post_id, 'artpulse_event_type', ['fields' => 'slugs']);
-        $category_names = wp_get_post_terms($post_id, 'artpulse_event_type', ['fields' => 'names']);
+        $categories = wp_get_post_terms($post_id, PostTypeRegistrar::EVENT_TAXONOMY, ['fields' => 'slugs']);
+        $category_names = wp_get_post_terms($post_id, PostTypeRegistrar::EVENT_TAXONOMY, ['fields' => 'names']);
 
         $is_favorited = false;
         if ($current_user_id > 0) {
-            $is_favorited = FavoritesManager::is_favorited($current_user_id, $post_id, 'artpulse_event');
+            $is_favorited = FavoritesManager::is_favorited($current_user_id, $post_id, PostTypeRegistrar::EVENT_POST_TYPE);
         }
 
         $schema = [
@@ -352,6 +683,8 @@ class EventsController
             'title'            => get_the_title($post_id),
             'start'            => $start ? self::format_iso($start, $timezone) : '',
             'end'              => $end ? self::format_iso($end, $timezone) : '',
+            'startUtc'         => self::format_utc($start),
+            'endUtc'           => self::format_utc($end),
             'allDay'           => $all_day,
             'timezone'         => $timezone,
             'location'         => $location,
@@ -371,194 +704,55 @@ class EventsController
 
     private static function expand_occurrences(array $event, ?DateTimeImmutable $range_start, ?DateTimeImmutable $range_end): array
     {
-        $start = self::parse_date($event['start']);
-        if (!$start instanceof DateTimeImmutable) {
-            return [];
-        }
-
-        $end = self::parse_date($event['end']);
-        if (!$end instanceof DateTimeImmutable) {
-            $end = $event['allDay'] ? $start : $start->add(new DateInterval('PT1H'));
-        }
-
-        $occurrences = [];
-        $base = [
-            'id'        => $event['id'],
-            'title'     => $event['title'],
-            'allDay'    => $event['allDay'],
-            'timezone'  => $event['timezone'],
-            'location'  => $event['location'],
-            'cost'      => $event['cost'],
-            'url'       => $event['url'],
-            'favorite'  => $event['favorite'],
-            'start'     => $start->format(DateTimeInterface::ATOM),
-            'end'       => $end->format(DateTimeInterface::ATOM),
-        ];
-
-        $rule = $event['recurrence'];
-        if (!$rule) {
-            if (self::occurrence_in_range($start, $end, $range_start, $range_end)) {
-                $occurrences[] = $base;
-            }
-
-            return $occurrences;
-        }
-
-        $parsed = self::parse_recurrence_rule($rule);
-        if (!$parsed) {
-            if (self::occurrence_in_range($start, $end, $range_start, $range_end)) {
-                $occurrences[] = $base;
-            }
-
-            return $occurrences;
-        }
-
-        $frequency = $parsed['freq'];
-        $interval  = max(1, (int) $parsed['interval']);
-        $until     = $parsed['until'];
-        $count     = $parsed['count'];
-
-        $cursor_start = $start;
-        $cursor_end   = $end;
-        $index        = 0;
-
-        while (true) {
-            if ($count && $index >= $count) {
-                break;
-            }
-
-            if ($until && $cursor_start > $until) {
-                break;
-            }
-
-            if (self::occurrence_in_range($cursor_start, $cursor_end, $range_start, $range_end)) {
-                $occurrences[] = $base + [
-                    'start' => $cursor_start->format(DateTimeInterface::ATOM),
-                    'end'   => $cursor_end->format(DateTimeInterface::ATOM),
-                ];
-            }
-
-            $index++;
-            switch ($frequency) {
-                case 'DAILY':
-                    $cursor_start = $cursor_start->add(new DateInterval('P' . $interval . 'D'));
-                    $cursor_end   = $cursor_end->add(new DateInterval('P' . $interval . 'D'));
-                    break;
-                case 'WEEKLY':
-                    $cursor_start = $cursor_start->add(new DateInterval('P' . $interval . 'W'));
-                    $cursor_end   = $cursor_end->add(new DateInterval('P' . $interval . 'W'));
-                    break;
-                case 'MONTHLY':
-                    $cursor_start = $cursor_start->add(new DateInterval('P' . $interval . 'M'));
-                    $cursor_end   = $cursor_end->add(new DateInterval('P' . $interval . 'M'));
-                    break;
-                default:
-                    $cursor_start = $cursor_start->add(new DateInterval('P' . $interval . 'D'));
-                    $cursor_end   = $cursor_end->add(new DateInterval('P' . $interval . 'D'));
-                    break;
-            }
-
-            if ($range_end && $cursor_start > $range_end->add(new DateInterval('P1D'))) {
-                break;
-            }
-        }
-
-        return $occurrences;
+        return RecurrenceExpander::expand($event, $range_start, $range_end);
     }
 
-    private static function occurrence_in_range(DateTimeImmutable $start, DateTimeImmutable $end, ?DateTimeImmutable $range_start, ?DateTimeImmutable $range_end): bool
+    private static function sanitize_date_param($value): ?string
     {
-        if ($range_start && $end < $range_start) {
-            return false;
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DateTimeInterface::ATOM);
         }
 
-        if ($range_end && $start > $range_end) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static function parse_recurrence_rule(string $rule): ?array
-    {
-        $rule = trim($rule);
-        if ('' === $rule) {
+        if (!is_string($value)) {
             return null;
         }
 
-        if (str_starts_with($rule, 'RRULE:')) {
-            $rule = substr($rule, 6);
-        }
+        $value = trim($value);
 
-        $parts = wp_parse_list($rule);
-        $data  = [
-            'freq'     => 'DAILY',
-            'interval' => 1,
-            'count'    => null,
-            'until'    => null,
-        ];
-
-        foreach ($parts as $part) {
-            if (!str_contains($part, '=')) {
-                continue;
-            }
-            [$key, $value] = array_map('trim', explode('=', $part, 2));
-            $key   = strtoupper($key);
-            $value = strtoupper($value);
-
-            switch ($key) {
-                case 'FREQ':
-                    if (in_array($value, ['DAILY', 'WEEKLY', 'MONTHLY'], true)) {
-                        $data['freq'] = $value;
-                    }
-                    break;
-                case 'INTERVAL':
-                    $data['interval'] = (int) $value ?: 1;
-                    break;
-                case 'COUNT':
-                    $data['count'] = (int) $value ?: null;
-                    break;
-                case 'UNTIL':
-                    $until = self::parse_date($value);
-                    if ($until instanceof DateTimeImmutable) {
-                        $data['until'] = $until;
-                    }
-                    break;
-            }
-        }
-
-        return $data;
+        return '' === $value ? null : $value;
     }
 
-    private static function sanitize_date($value): ?string
+    private static function sanitize_positive_int($value): ?int
     {
-        if (empty($value)) {
-            return null;
+        if (is_numeric($value)) {
+            $int = (int) $value;
+
+            return $int > 0 ? $int : null;
         }
 
-        $parsed = self::parse_date($value);
-        return $parsed ? $parsed->format(DateTimeInterface::ATOM) : null;
+        return null;
     }
 
-    private static function sanitize_array_param($value): array
+    private static function sanitize_orderby_param($value): string
     {
-        if (empty($value)) {
-            return [];
-        }
+        $value = strtolower((string) $value);
 
-        if (is_string($value)) {
-            $value = explode(',', $value);
-        }
-
-        return array_values(array_filter(array_map('sanitize_text_field', (array) $value)));
+        return in_array($value, ['event_start', 'title'], true) ? $value : 'event_start';
     }
 
-    private static function sanitize_orderby($value): string
+    private static function sanitize_order_param($value): string
     {
-        $allowed = ['start', 'end', 'title'];
-        $value   = strtolower((string) $value);
+        return 'DESC' === strtoupper((string) $value) ? 'DESC' : 'ASC';
+    }
 
-        return in_array($value, $allowed, true) ? $value : 'start';
+    private static function sanitize_taxonomy_param($value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    private static function sanitize_boolean_param($value): int
+    {
+        return self::to_bool($value) ? 1 : 0;
     }
 
     private static function parse_date($value): ?DateTimeImmutable
@@ -599,10 +793,24 @@ class EventsController
         return $date->setTimezone($tz)->format(DateTimeInterface::ATOM);
     }
 
-    private static function get_cache_key(array $args, bool $apply_pagination): string
+    private static function format_utc(?string $value): string
+    {
+        if (empty($value)) {
+            return '';
+        }
+
+        $date = self::parse_date($value);
+
+        return $date ? $date->setTimezone(new DateTimeZone('UTC'))->format(DateTimeInterface::ATOM) : '';
+    }
+
+    private static function get_cache_key(array $fingerprint, bool $apply_pagination, string $suffix = 'events'): string
     {
         $version = (int) get_option(self::CACHE_VERSION_OPTION, 1);
-        return $version . ':' . md5(wp_json_encode($args) . ($apply_pagination ? ':1' : ':0'));
+        $encoded = wp_json_encode($fingerprint);
+        $toggle  = $apply_pagination ? ':1' : ':0';
+
+        return $version . ':' . $suffix . ':' . md5((string) $encoded . $toggle);
     }
 
     public static function purge_cache(): void

--- a/tests/Integration/RecurrenceTest.php
+++ b/tests/Integration/RecurrenceTest.php
@@ -3,6 +3,7 @@
 namespace ArtPulse\Tests\Integration;
 
 use ArtPulse\Core\PostTypeRegistrar;
+use ArtPulse\Integration\Recurrence\RecurrenceExpander;
 use ArtPulse\Rest\EventsController;
 use WP_UnitTestCase;
 
@@ -14,25 +15,92 @@ class RecurrenceTest extends WP_UnitTestCase
         PostTypeRegistrar::register();
     }
 
-    public function test_weekly_recurrence_generates_multiple_occurrences(): void
+    public function test_weekly_recurrence_handles_dst_transition(): void
     {
         $event_id = self::factory()->post->create([
-            'post_type'   => 'artpulse_event',
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
             'post_status' => 'publish',
             'post_title'  => 'Weekly Meetup',
         ]);
 
-        update_post_meta($event_id, '_ap_event_start', '2024-09-01T10:00:00+00:00');
-        update_post_meta($event_id, '_ap_event_end', '2024-09-01T12:00:00+00:00');
-        update_post_meta($event_id, '_ap_event_recurrence', 'RRULE:FREQ=WEEKLY;COUNT=4');
+        update_post_meta($event_id, '_ap_event_start', '2024-03-03T10:00:00-05:00');
+        update_post_meta($event_id, '_ap_event_end', '2024-03-03T12:00:00-05:00');
+        update_post_meta($event_id, '_ap_event_timezone', 'America/New_York');
+        update_post_meta($event_id, '_ap_event_recurrence', 'RRULE:FREQ=WEEKLY;COUNT=3');
 
         $results = EventsController::fetch_events([
-            'start' => '2024-09-01T00:00:00+00:00',
-            'end'   => '2024-09-30T23:59:59+00:00',
+            'start' => '2024-03-01T00:00:00+00:00',
+            'end'   => '2024-03-20T23:59:59+00:00',
+            'per_page' => 50,
         ]);
 
-        $this->assertCount(4, $results['events']);
+        $this->assertCount(3, $results['events']);
         $starts = array_map(static fn($event) => $event['start'], $results['events']);
-        $this->assertSame('2024-09-01T10:00:00+00:00', $starts[0]);
+        $this->assertSame(['2024-03-03T15:00:00+00:00', '2024-03-10T14:00:00+00:00', '2024-03-17T14:00:00+00:00'], $starts);
+    }
+
+    public function test_occurrence_includes_events_overlapping_range_start(): void
+    {
+        $event_id = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Late Night Show',
+        ]);
+
+        update_post_meta($event_id, '_ap_event_start', '2024-04-01T23:30:00+00:00');
+        update_post_meta($event_id, '_ap_event_end', '2024-04-02T01:00:00+00:00');
+
+        $results = EventsController::fetch_events([
+            'start' => '2024-04-02T00:00:00+00:00',
+            'end'   => '2024-04-02T23:59:59+00:00',
+        ]);
+
+        $ids = wp_list_pluck($results['events'], 'id');
+        $this->assertSame([$event_id], $ids);
+    }
+
+    public function test_mixed_rrule_and_rdate_without_duplicates(): void
+    {
+        $event_id = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Hybrid Schedule',
+        ]);
+
+        update_post_meta($event_id, '_ap_event_start', '2024-09-01T10:00:00+00:00');
+        update_post_meta($event_id, '_ap_event_end', '2024-09-01T11:00:00+00:00');
+        update_post_meta($event_id, '_ap_event_recurrence', "RRULE:FREQ=DAILY;COUNT=2\nRDATE:2024-09-02T10:00:00+00:00,2024-09-02T10:00:00+00:00");
+
+        $results = EventsController::fetch_events([
+            'start' => '2024-09-01',
+            'end'   => '2024-09-05',
+            'per_page' => 10,
+        ]);
+
+        $this->assertCount(2, $results['events']);
+        $starts = array_column($results['events'], 'start');
+        $this->assertSame(['2024-09-01T10:00:00+00:00', '2024-09-02T10:00:00+00:00'], $starts);
+    }
+
+    public function test_truncation_flag_when_instance_limit_exceeded(): void
+    {
+        $event_id = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Daily Marathon',
+        ]);
+
+        update_post_meta($event_id, '_ap_event_start', '2024-01-01T08:00:00+00:00');
+        update_post_meta($event_id, '_ap_event_end', '2024-01-01T09:00:00+00:00');
+        update_post_meta($event_id, '_ap_event_recurrence', 'RRULE:FREQ=DAILY;COUNT=1500');
+
+        $results = EventsController::fetch_events([
+            'start'    => '2024-01-01',
+            'end'      => '2024-12-31',
+            'per_page' => 2000,
+        ], false);
+
+        $this->assertTrue($results['truncated']);
+        $this->assertCount(RecurrenceExpander::MAX_INSTANCES, $results['events']);
     }
 }

--- a/tests/Rest/EventsControllerTest.php
+++ b/tests/Rest/EventsControllerTest.php
@@ -5,6 +5,8 @@ namespace ArtPulse\Tests\Rest;
 use ArtPulse\Community\FavoritesManager;
 use ArtPulse\Core\PostTypeRegistrar;
 use ArtPulse\Rest\EventsController;
+use DateTimeInterface;
+use WP_REST_Request;
 use WP_UnitTestCase;
 
 class EventsControllerTest extends WP_UnitTestCase
@@ -14,12 +16,13 @@ class EventsControllerTest extends WP_UnitTestCase
         parent::setUp();
         PostTypeRegistrar::register();
         FavoritesManager::install_favorites_table();
+        EventsController::purge_cache();
     }
 
     public function test_fetch_events_respects_date_range(): void
     {
         $event_in_range = self::factory()->post->create([
-            'post_type'   => 'artpulse_event',
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
             'post_status' => 'publish',
             'post_title'  => 'Gallery Opening',
         ]);
@@ -28,7 +31,7 @@ class EventsControllerTest extends WP_UnitTestCase
         update_post_meta($event_in_range, '_ap_event_end', '2024-09-10T20:00:00+00:00');
 
         $event_out_of_range = self::factory()->post->create([
-            'post_type'   => 'artpulse_event',
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
             'post_status' => 'publish',
             'post_title'  => 'Future Expo',
         ]);
@@ -52,7 +55,7 @@ class EventsControllerTest extends WP_UnitTestCase
         wp_set_current_user($user_id);
 
         $fav_event = self::factory()->post->create([
-            'post_type'   => 'artpulse_event',
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
             'post_status' => 'publish',
             'post_title'  => 'Collectors Night',
         ]);
@@ -60,7 +63,7 @@ class EventsControllerTest extends WP_UnitTestCase
         update_post_meta($fav_event, '_ap_event_start', '2024-10-05T18:00:00+00:00');
         update_post_meta($fav_event, '_ap_event_end', '2024-10-05T20:00:00+00:00');
 
-        FavoritesManager::add_favorite($user_id, $fav_event, 'artpulse_event');
+        FavoritesManager::add_favorite($user_id, $fav_event, PostTypeRegistrar::EVENT_POST_TYPE);
 
         $results = EventsController::fetch_events([
             'start'     => '2024-10-01T00:00:00+00:00',
@@ -70,6 +73,164 @@ class EventsControllerTest extends WP_UnitTestCase
 
         $ids = wp_list_pluck($results['events'], 'id');
         $this->assertSame([$fav_event], $ids);
+    }
+
+    public function test_unknown_taxonomy_is_ignored(): void
+    {
+        $term = self::factory()->term->create(['taxonomy' => PostTypeRegistrar::EVENT_TAXONOMY, 'slug' => 'opening']);
+
+        $event = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Art Opening',
+        ]);
+
+        wp_set_object_terms($event, [$term], PostTypeRegistrar::EVENT_TAXONOMY);
+        update_post_meta($event, '_ap_event_start', '2024-11-10T18:00:00+00:00');
+        update_post_meta($event, '_ap_event_end', '2024-11-10T20:00:00+00:00');
+
+        $request = new WP_REST_Request('GET', '/artpulse/v1/events');
+        $request->set_param('start', '2024-11-01');
+        $request->set_param('end', '2024-11-30');
+        $request->set_param('taxonomy', [
+            PostTypeRegistrar::EVENT_TAXONOMY => ['opening'],
+            'fake_taxonomy'                  => ['ignored'],
+        ]);
+
+        $response = EventsController::get_events($request);
+        $data     = $response->get_data();
+
+        $this->assertCount(1, $data['events']);
+        $this->assertSame($event, $data['events'][0]['id']);
+    }
+
+    public function test_per_page_is_clamped_to_maximum(): void
+    {
+        $start = new \DateTimeImmutable('2024-08-01T12:00:00+00:00');
+
+        for ($i = 0; $i < 120; $i++) {
+            $post_id = self::factory()->post->create([
+                'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+                'post_status' => 'publish',
+                'post_title'  => 'Event ' . $i,
+            ]);
+
+            $current = $start->add(new \DateInterval('P' . $i . 'D'));
+            update_post_meta($post_id, '_ap_event_start', $current->format(DateTimeInterface::ATOM));
+            update_post_meta($post_id, '_ap_event_end', $current->modify('+2 hours')->format(DateTimeInterface::ATOM));
+        }
+
+        $results = EventsController::fetch_events([
+            'start'    => '2024-08-01',
+            'end'      => '2024-12-31',
+            'per_page' => 500,
+        ]);
+
+        $this->assertSame(100, $results['pagination']['per_page']);
+        $this->assertCount(100, $results['events']);
+    }
+
+    public function test_orderby_falls_back_to_event_start(): void
+    {
+        $early = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Early Event',
+        ]);
+        $late = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Late Event',
+        ]);
+
+        update_post_meta($early, '_ap_event_start', '2024-07-01T10:00:00+00:00');
+        update_post_meta($early, '_ap_event_end', '2024-07-01T12:00:00+00:00');
+        update_post_meta($late, '_ap_event_start', '2024-07-10T10:00:00+00:00');
+        update_post_meta($late, '_ap_event_end', '2024-07-10T12:00:00+00:00');
+
+        $results = EventsController::fetch_events([
+            'start'   => '2024-07-01',
+            'end'     => '2024-07-31',
+            'orderby' => 'unsupported',
+            'order'   => 'ASC',
+        ]);
+
+        $this->assertSame($early, $results['events'][0]['id']);
+    }
+
+    public function test_etag_header_is_consistent_across_requests(): void
+    {
+        $event = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Caching Test',
+        ]);
+
+        update_post_meta($event, '_ap_event_start', '2024-06-05T18:00:00+00:00');
+        update_post_meta($event, '_ap_event_end', '2024-06-05T20:00:00+00:00');
+
+        $request = new WP_REST_Request('GET', '/artpulse/v1/events');
+        $request->set_param('start', '2024-06-01');
+        $request->set_param('end', '2024-06-30');
+
+        $responseOne = EventsController::get_events($request);
+        $etag        = $responseOne->get_headers()['ETag'] ?? '';
+        $this->assertNotEmpty($etag);
+
+        $responseTwo = EventsController::get_events($request);
+        $this->assertSame($etag, $responseTwo->get_headers()['ETag'] ?? '');
+        $this->assertSame($responseOne->get_data(), $responseTwo->get_data());
+    }
+
+    public function test_if_none_match_returns_304(): void
+    {
+        $event = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Cached Response',
+        ]);
+
+        update_post_meta($event, '_ap_event_start', '2024-05-10T18:00:00+00:00');
+        update_post_meta($event, '_ap_event_end', '2024-05-10T20:00:00+00:00');
+
+        $request = new WP_REST_Request('GET', '/artpulse/v1/events');
+        $request->set_param('start', '2024-05-01');
+        $request->set_param('end', '2024-05-31');
+
+        $initial   = EventsController::get_events($request);
+        $etag      = $initial->get_headers()['ETag'] ?? '';
+
+        $request->set_header('If-None-Match', $etag);
+        $cachedResponse = EventsController::get_events($request);
+
+        $this->assertSame(304, $cachedResponse->get_status());
+        $this->assertNull($cachedResponse->get_data());
+    }
+
+    public function test_ics_endpoint_honors_etag_headers(): void
+    {
+        $event = self::factory()->post->create([
+            'post_type'   => PostTypeRegistrar::EVENT_POST_TYPE,
+            'post_status' => 'publish',
+            'post_title'  => 'Calendar Export',
+        ]);
+
+        update_post_meta($event, '_ap_event_start', '2024-08-15T18:00:00+00:00');
+        update_post_meta($event, '_ap_event_end', '2024-08-15T20:00:00+00:00');
+
+        $request = new WP_REST_Request('GET', '/artpulse/v1/events.ics');
+        $request->set_param('start', '2024-08-01');
+        $request->set_param('end', '2024-08-31');
+
+        $response = EventsController::get_ics($request);
+        $etag     = $response->get_headers()['ETag'] ?? '';
+        $this->assertNotEmpty($etag);
+
+        $request->set_header('If-None-Match', $etag);
+        $notModified = EventsController::get_ics($request);
+
+        $this->assertSame(304, $notModified->get_status());
+        $this->assertNull($notModified->get_data());
     }
 
     public function test_generate_ics_contains_event_summary(): void


### PR DESCRIPTION
## Summary
- harden the events REST controller by normalizing the allow-listed parameters, sanitizing taxonomy filters, adding cache-aware ETag handling, and delegating recurrence expansion to a DST-safe expander
- introduce a recurrence expander service with truncation safeguards plus comprehensive REST and recurrence integration tests covering parameter validation, caching behaviour, and overlapping instances
- document the CI phpunit workflow, ensure the workflow exports `WP_PHPUNIT__DIR`, and surface constants for the events post type/taxonomy

## Testing
- `composer install --no-interaction --prefer-dist` *(fails in this environment because GitHub-hosted sources require network access)*
- `vendor/bin/phpunit --testdox` *(not run: dependencies unavailable due to the install failure above)*

------
https://chatgpt.com/codex/tasks/task_e_68e37989b2f0832e82c677e652c3747c