### PR TITLE
Add fallbacks for event thumbnails and cover image rendering

### DIFF
--- a/src/Rest/EventsController.php
+++ b/src/Rest/EventsController.php
@@ -641,7 +641,16 @@ class EventsController
         $org_name = $org_id ? get_the_title($org_id) : '';
 
         $thumb_id = get_post_thumbnail_id($post_id);
-        $thumbnail = $thumb_id ? wp_get_attachment_image_url($thumb_id, 'large') : '';
+        $thumbnail = '';
+        if ($thumb_id) {
+            $thumbnail = wp_get_attachment_image_url($thumb_id, 'large') ?: '';
+            if (!$thumbnail) {
+                $thumbnail = wp_get_attachment_image_url($thumb_id, 'medium_large') ?: '';
+            }
+            if (!$thumbnail) {
+                $thumbnail = wp_get_attachment_image_url($thumb_id, 'full') ?: '';
+            }
+        }
         $excerpt   = wp_strip_all_tags(get_the_excerpt($post_id));
 
         $categories = wp_get_post_terms($post_id, PostTypeRegistrar::EVENT_TAXONOMY, ['fields' => 'slugs']);

--- a/tests/Frontend/EventsCalendarTest.php
+++ b/tests/Frontend/EventsCalendarTest.php
@@ -9,6 +9,8 @@ use WP_UnitTestCase;
 
 class EventsCalendarTest extends WP_UnitTestCase
 {
+    private const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jrV8AAAAASUVORK5CYII=';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -16,6 +18,7 @@ class EventsCalendarTest extends WP_UnitTestCase
         if (!defined('ARTPULSE_PLUGIN_FILE')) {
             define('ARTPULSE_PLUGIN_FILE', dirname(__DIR__, 1) . '/../artpulse-management.php');
         }
+        add_theme_support('post-thumbnails');
     }
 
     public function test_grid_layout_renders_salient_classes(): void
@@ -62,5 +65,77 @@ class EventsCalendarTest extends WP_UnitTestCase
 
         $this->assertStringContainsString('data-ap-events="', $output);
         $this->assertStringContainsString('ap-events--calendar', $output);
+    }
+
+    public function test_grid_layout_displays_thumbnail_and_event_meta(): void
+    {
+        $attachment_id = self::create_attachment_without_large_size();
+        $this->assertFalse(wp_get_attachment_image_url($attachment_id, 'large'));
+        $expected_image = wp_get_attachment_image_url($attachment_id, 'full');
+        $this->assertNotFalse($expected_image);
+
+        $event_id = self::factory()->post->create([
+            'post_type'   => 'artpulse_event',
+            'post_status' => 'publish',
+            'post_title'  => 'Thumbnail Showcase',
+        ]);
+
+        update_post_meta($event_id, '_ap_event_start', '2024-09-15T14:00:00+00:00');
+        update_post_meta($event_id, '_ap_event_end', '2024-09-15T16:00:00+00:00');
+        set_post_thumbnail($event_id, $attachment_id);
+
+        update_option('date_format', 'F j, Y');
+        update_option('time_format', 'g:i a');
+
+        $output = EventsCalendar::render_shortcode([
+            'layout'       => 'grid',
+            'show_filters' => 'false',
+            'per_page'     => 6,
+        ]);
+
+        $this->assertStringContainsString('Thumbnail Showcase', $output);
+        $this->assertStringContainsString($expected_image, $output);
+        $this->assertMatchesRegularExpression('/<img[^>]+alt="Thumbnail Showcase"/i', $output);
+
+        $expected_date = wp_date(get_option('date_format') . ' ' . get_option('time_format'), strtotime('2024-09-15T14:00:00+00:00'));
+        $this->assertStringContainsString($expected_date, $output);
+    }
+
+    private static function create_attachment_without_large_size(string $filename = 'no-large.png'): int
+    {
+        $data = base64_decode(self::TINY_PNG_BASE64, true);
+        if (false === $data) {
+            throw new \RuntimeException('Failed to decode base64 image fixture.');
+        }
+
+        $upload = wp_upload_bits($filename, null, $data);
+        if (!empty($upload['error'])) {
+            throw new \RuntimeException('Failed to write attachment fixture: ' . $upload['error']);
+        }
+
+        $file     = $upload['file'];
+        $filetype = wp_check_filetype($filename, null);
+
+        $attachment_id = wp_insert_attachment([
+            'post_mime_type' => $filetype['type'] ?? 'image/png',
+            'post_title'     => sanitize_file_name($filename),
+            'post_content'   => '',
+            'post_status'    => 'inherit',
+        ], $file);
+
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+        add_filter('intermediate_image_sizes_advanced', [self::class, 'filter_remove_large_sizes']);
+        $metadata = wp_generate_attachment_metadata($attachment_id, $file);
+        remove_filter('intermediate_image_sizes_advanced', [self::class, 'filter_remove_large_sizes']);
+        wp_update_attachment_metadata($attachment_id, $metadata);
+
+        return $attachment_id;
+    }
+
+    public static function filter_remove_large_sizes($sizes)
+    {
+        unset($sizes['large'], $sizes['medium_large']);
+
+        return $sizes;
     }
 }

--- a/tests/Integration/EventFeaturedImageTest.php
+++ b/tests/Integration/EventFeaturedImageTest.php
@@ -100,6 +100,10 @@ class EventFeaturedImageTest extends WP_UnitTestCase
         $thumbnail_id = get_post_thumbnail_id($post_id);
         $this->assertSame($attachment_id, $thumbnail_id);
 
+        $image_url = wp_get_attachment_url($attachment_id);
+        $this->assertNotFalse($image_url);
+        $this->assertContains($image_url, $data['images']);
+
         $metadata = wp_get_attachment_metadata($thumbnail_id);
         $this->assertIsArray($metadata);
         $this->assertArrayHasKey('sizes', $metadata);


### PR DESCRIPTION
## Summary
- fall back to medium and full image sizes when preparing event thumbnails for the grid
- ensure REST submission responses surface uploaded image URLs for portfolio use
- add regression coverage that verifies grid markup renders thumbnails, titles, and dates when only full-size images exist

## Testing
- composer install *(fails: GitHub API 403 while downloading dealerdirect/phpcodesniffer-composer-installer)*

------
https://chatgpt.com/codex/tasks/task_e_68e559072e74832ead4717c4513b6217