### PR TITLE
Improve Composer authentication and caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
-          tools: composer
+          tools: composer:v2
           extensions: mbstring, mysqli, gd, intl, zip
 
       - name: Configure Composer GitHub OAuth
@@ -64,17 +64,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      - name: Determine Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Composer dependencies
+      - name: Cache Composer
         uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
+          path: |
+            ~/.composer/cache/files
+            vendor
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
 
       - name: Validate PHP syntax
         run: |

--- a/.github/workflows/e2e-community.yml
+++ b/.github/workflows/e2e-community.yml
@@ -24,10 +24,25 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+          extensions: mbstring, gd, intl, zip
+          tools: composer:v2
           coverage: none
 
       - name: Install Node dependencies
         run: npm ci
+
+      - name: Configure Composer GitHub OAuth
+        run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache/files
+            vendor
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-
 
       - name: Cache Playwright binaries
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, gd, intl, zip
+          tools: composer:v2
+          coverage: none
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
+
+      - name: Configure Composer GitHub OAuth
+        run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Composer (for wp-cli/wp-env deps if needed)
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ Run the test suite with:
 vendor/bin/phpunit --testdox
 ```
 
+### Composer authentication
+
+Composer requires GitHub authentication to avoid API rate limits when installing
+packages from repositories hosted on GitHub. Configure OAuth once locally before
+running `composer install`:
+
+```bash
+composer config -g github-oauth.github.com YOUR_GH_PAT
+```
+
+Alternatively, write the credentials directly to `~/.composer/auth.json`:
+
+```bash
+mkdir -p ~/.composer
+printf '{ "github-oauth": { "github.com": "YOUR_GH_PAT" } }' > ~/.composer/auth.json
+```
+
+If you must work in an environment without GitHub access, restore a pre-built
+`vendor/` directory or point Composer at an internal Packagist mirror:
+
+```bash
+composer config -g repos.packagist composer https://packagist.mycompany.com
+```
+
 Tests also run automatically in CI via GitHub Actions, which installs Composer
 dependencies (`composer install --no-interaction --prefer-dist`) and executes
 `vendor/bin/phpunit --testdox --colors=always` with `WP_PHPUNIT__DIR` pointing to

--- a/tests/Integration/EventFeaturedImageTest.php
+++ b/tests/Integration/EventFeaturedImageTest.php
@@ -201,6 +201,7 @@ class EventFeaturedImageTest extends WP_UnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('<div class="ap-event-placeholder" aria-hidden="true"></div>', $output);
+        $this->assertMatchesRegularExpression('/<div class="nectar-portfolio-single-media">\s*<div class="ap-event-placeholder"[^>]*><\/div>\s*<\/div>/', $output);
         $this->assertDoesNotMatchRegularExpression('/<img[^>]+ap-event-img/', $output);
 
         wp_reset_postdata();


### PR DESCRIPTION
## Summary
- configure Composer OAuth, cache vendor directories, and ensure composer v2 across CI workflows
- document local Composer authentication steps and offline fallbacks for developers
- strengthen the single-event placeholder integration test

## Testing
- composer install --no-interaction --prefer-dist *(fails: GitHub CONNECT 403 when downloading dependencies in sandbox)*
- composer test:int *(blocked: vendor/bin/phpunit missing because Composer install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68e561ae96c0832e994d630633fc073b