### PR TITLE
Harden organization upgrade workflow and builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## Unreleased
 
+### Added
+- Harden the organization upgrade workflow: attach ownership metadata idempotently, guard builder/event submission with
+  nonces and capability checks, expand the shortcode to cover profile/images/preview/publish steps, and surface owner-locked
+  event submissions with friendly validation.
+- Extend REST endpoints and admin review tools with requester context, approval/denial logging, and normalized metadata for
+  owned organizations.
+- Document the member → organization lifecycle and add integration coverage for approvals, builder saves, featured media,
+  and event submission locking.
+
 ### Fix
 - Repair membership test fixtures and WooCommerce reflection usage so PHPUnit bootstrap succeeds without typos.
 - Normalize REST test cases to use core `\WP_UnitTestCase` without redundant imports, preventing syntax lint warnings.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,43 @@ ArtPulse Management is a powerful WordPress plugin that enables seamless managem
 🧭 Organization Onboarding — `[ap_register_organization]` shortcode to collect org sign-ups, auto-assign creators, notify admins, and promote follow/favorite actions
 🏗️ Organization Builder — `[ap_org_builder]` shortcode for approved org owners to edit profiles, manage media, preview, publish, and submit events
 
+## Organization upgrade workflow
+
+Members start from the dashboard upgrade card. Requesting an upgrade creates a
+draft organization tied to the requester and records a review entry with a
+`pending` status. While the request is pending, the builder shortcode renders a
+friendly notice and keeps editing locked until approval.
+
+Site administrators review requests at **ArtPulse → Upgrade Reviews**. The list
+table shows the draft organization title, requester details, and the submitted
+time with quick Approve/Deny row actions. Approving a request publishes the
+organization, attaches the owner (post author + `_ap_owner_user`), grants the
+`organization` role if needed, logs the action, and sends a single upgrade email
+thanks to the `_ap_upgrade_notified_{role}` meta guard. Denying a request stores
+the supplied reason, emails the member, and leaves the organization in draft
+for follow-up edits.
+
+Approved owners can access `[ap_org_builder]`, which now walks through Profile,
+Images, Preview, and Publish steps. The Images screen supports logo/cover
+uploads, gallery sorting via order inputs, and a “Use as featured” toggle that
+keeps aspect ratio placeholders in place to avoid layout shifts. A persistent
+Submit Event button links directly to the locked event form.
+
+Submitting events from either the builder button or `[ap_org_submit_event]`
+verifies capabilities, enforces ownership (matching `_ap_owner_user` or
+`post_author`), and validates uploads (JPG/PNG/WebP, max 10 MB, minimum 200×200
+pixels). Spoofed organization IDs are ignored in favor of the owner’s approved
+organization, both in the front-end form and via the REST submissions endpoint.
+
+Email triggers fire at three key moments:
+
+* Upgrade requested — confirmation sent to the member.
+* Upgrade approved — dashboard link + instructions once the admin approves.
+* Upgrade denied — includes the recorded reason for transparency.
+
+These notifications are idempotent to prevent duplicate sends when an approval
+is processed more than once.
+
 🧑‍💻 Installation
 Clone or download this repo into your WordPress plugins directory:
 

--- a/src/Frontend/OrganizationEventForm.php
+++ b/src/Frontend/OrganizationEventForm.php
@@ -2,7 +2,15 @@
 
 namespace ArtPulse\Frontend;
 
+use WP_Error;
+use WP_Post;
+use WP_User;
+
 class OrganizationEventForm {
+
+    private const ERROR_TRANSIENT_PREFIX = 'ap_org_event_errors_';
+    private const MAX_IMAGE_BYTES = 10 * MB_IN_BYTES;
+    private const MIN_IMAGE_DIMENSION = 200;
 
     public static function register() {
         add_shortcode('ap_org_submit_event', [self::class, 'render']);
@@ -22,25 +30,31 @@ class OrganizationEventForm {
             return '<p>You must be logged in to submit an event.</p>';
         }
 
-        $org_id = isset($_GET['org_id']) ? absint($_GET['org_id']) : 0;
+        $user_id = get_current_user_id();
+        $org_id = self::get_user_org_id($user_id);
 
-        if ($org_id) {
-            $owner_id = (int) get_post_meta($org_id, '_ap_owner_user', true);
-            if (!$owner_id) {
-                $org = get_post($org_id);
-                if ($org instanceof \WP_Post) {
-                    $owner_id = (int) $org->post_author;
-                }
-            }
+        if (!$org_id) {
+            return '<p>' . esc_html__('You need an approved organization before submitting events.', 'artpulse-management') . '</p>';
+        }
 
-            if ($owner_id !== get_current_user_id()) {
-                return '<p>' . esc_html__('You do not have permission to submit events for this organization.', 'artpulse-management') . '</p>';
-            }
+        if (!current_user_can('create_artpulse_events')) {
+            return '<p>' . esc_html__('Your account is not allowed to submit events.', 'artpulse-management') . '</p>';
         }
 
         // Show success message if redirected after submission
         if (!empty($_GET['event_submitted'])) {
             echo '<div class="ap-success-message">✅ Event submitted successfully!</div>';
+        }
+
+        $errors = self::pull_errors($user_id);
+        if (!empty($errors)) {
+            echo '<div class="ap-error-message" role="alert">';
+            echo '<ul>';
+            foreach ($errors as $message) {
+                echo '<li>' . esc_html($message) . '</li>';
+            }
+            echo '</ul>';
+            echo '</div>';
         }
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['ap_event_nonce']) && wp_verify_nonce($_POST['ap_event_nonce'], 'submit_event')) {
@@ -78,7 +92,8 @@ class OrganizationEventForm {
             </select>
 
             <label for="ap_org_event_flyer">Event Flyer</label>
-            <input id="ap_org_event_flyer" type="file" name="event_flyer">
+            <input id="ap_org_event_flyer" type="file" name="event_flyer" accept="image/jpeg,image/png,image/webp">
+            <p class="description"><?php esc_html_e('Optional. JPG, PNG, or WebP. Max 10MB and at least 200×200 pixels.', 'artpulse-management'); ?></p>
 
             <button type="submit">Submit Event</button>
         </form>
@@ -87,50 +102,76 @@ class OrganizationEventForm {
     }
 
     public static function handle_submission(bool $should_redirect = true) {
-        $title = sanitize_text_field($_POST['title']);
-        $description = wp_kses_post($_POST['description']);
-        $date = sanitize_text_field($_POST['event_date']);
-        $location = sanitize_text_field($_POST['event_location']);
-        $type = intval($_POST['event_type']);
-        $org_id = isset($_POST['org_id']) ? absint($_POST['org_id']) : 0;
+        $user_id = get_current_user_id();
+        $org_id = self::get_user_org_id($user_id);
+
+        $errors = [];
+
+        if ($user_id <= 0 || !$org_id) {
+            $errors[] = __('You do not have permission to submit this event.', 'artpulse-management');
+            return self::maybe_handle_errors($errors, $should_redirect);
+        }
+
+        $title = sanitize_text_field(wp_unslash($_POST['title'] ?? ''));
+        $description = wp_kses_post(wp_unslash($_POST['description'] ?? ''));
+        $date = sanitize_text_field(wp_unslash($_POST['event_date'] ?? ''));
+        $location = sanitize_text_field(wp_unslash($_POST['event_location'] ?? ''));
+        $type = isset($_POST['event_type']) ? absint($_POST['event_type']) : 0;
+
+        if ($title === '') {
+            $errors[] = __('Please provide a title for the event.', 'artpulse-management');
+        }
+
+        if ($description === '') {
+            $errors[] = __('Please provide a description for the event.', 'artpulse-management');
+        }
+
+        if ($date === '') {
+            $errors[] = __('Please provide a date for the event.', 'artpulse-management');
+        }
+
+        if ($location === '') {
+            $errors[] = __('Please provide a location for the event.', 'artpulse-management');
+        }
+
+        if (!empty($errors)) {
+            return self::maybe_handle_errors($errors, $should_redirect);
+        }
 
         $post_id = wp_insert_post([
             'post_title'   => $title,
             'post_content' => $description,
             'post_type'    => 'artpulse_event',
             'post_status'  => 'pending',
-            'post_author'  => get_current_user_id(),
-        ]);
+            'post_author'  => $user_id,
+        ], true);
 
         if (is_wp_error($post_id)) {
-            return;
+            $errors[] = $post_id->get_error_message();
+            return self::maybe_handle_errors($errors, $should_redirect);
         }
 
         update_post_meta($post_id, '_ap_event_date', $date);
         update_post_meta($post_id, '_ap_event_location', $location);
-
-        if ($org_id) {
-            update_post_meta($post_id, '_ap_event_organization', $org_id);
-        }
+        update_post_meta($post_id, '_ap_event_organization', $org_id);
 
         if ($type) {
             wp_set_post_terms($post_id, [$type], 'artpulse_event_type');
         }
 
-        if (!empty($_FILES['event_flyer']['tmp_name'])) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-            require_once ABSPATH . 'wp-admin/includes/media.php';
-            require_once ABSPATH . 'wp-admin/includes/image.php';
-
-            $file = $_FILES['event_flyer'];
-            $check = wp_check_filetype_and_ext($file['tmp_name'], $file['name']);
-            if (empty($check['ext']) || strpos((string) ($check['type'] ?? ''), 'image/') !== 0) {
-                wp_die(esc_html__('Please upload a valid image.', 'artpulse-management'));
-            }
-
-            $attachment_id = media_handle_upload('event_flyer', $post_id);
-            if (!is_wp_error($attachment_id)) {
-                set_post_thumbnail($post_id, $attachment_id);
+        if (!empty($_FILES['event_flyer']['name'])) {
+            self::ensure_media_dependencies();
+            $file = self::prepare_file_array($_FILES['event_flyer']);
+            $validation = self::validate_image_upload($file, __('Event flyer', 'artpulse-management'));
+            if ($validation) {
+                $errors[] = $validation;
+            } else {
+                $attachment_id = media_handle_upload('event_flyer', $post_id);
+                if (is_wp_error($attachment_id)) {
+                    $errors[] = $attachment_id->get_error_message();
+                } else {
+                    set_post_thumbnail($post_id, $attachment_id);
+                }
             }
         }
 
@@ -140,7 +181,7 @@ class OrganizationEventForm {
         $message = sprintf(
             "A new event was submitted:\n\nTitle: %s\n\nBy User ID: %d\n\nEdit: %s",
             $title,
-            get_current_user_id(),
+            $user_id,
             admin_url("post.php?post={$post_id}&action=edit")
         );
         wp_mail($admin_email, $subject, $message);
@@ -148,19 +189,204 @@ class OrganizationEventForm {
         // User confirmation
         $current_user = wp_get_current_user();
         $user_email = $current_user->user_email;
-        $user_subject = 'Thanks for submitting your event';
-        $user_message = "Hi {$current_user->display_name},\n\nThanks for submitting your event \"{$title}\". It is now pending review.";
-        wp_mail($user_email, $user_subject, $user_message);
+        if ($user_email) {
+            $user_subject = __('Thanks for submitting your event', 'artpulse-management');
+            $user_message = sprintf(
+                /* translators: %s event title. */
+                __('Hi %1$s,%2$s%3$s', 'artpulse-management'),
+                $current_user->display_name ?: $current_user->user_login,
+                "\n\n",
+                sprintf(
+                    /* translators: %s event title. */
+                    __('Thanks for submitting your event "%s". It is now pending review.', 'artpulse-management'),
+                    $title
+                )
+            );
+            wp_mail($user_email, $user_subject, $user_message);
+        }
+
+        if (!empty($errors)) {
+            self::remember_errors($user_id, $errors);
+        } else {
+            self::remember_errors($user_id, []);
+        }
 
         if ($should_redirect) {
             $redirect = wp_get_referer();
             if (!$redirect) {
                 $redirect = add_query_arg('event_submitted', '1', home_url());
             }
-            wp_redirect(add_query_arg('event_submitted', '1', $redirect));
+
+            $redirect = add_query_arg('event_submitted', '1', $redirect);
+            wp_safe_redirect($redirect);
             exit;
         }
 
         return $post_id;
+    }
+
+    private static function maybe_handle_errors(array $errors, bool $should_redirect)
+    {
+        $errors = array_filter(array_map(static fn($message) => sanitize_text_field((string) $message), $errors));
+
+        if ($should_redirect) {
+            self::remember_errors(get_current_user_id(), $errors);
+            $redirect = wp_get_referer() ?: home_url('/dashboard/');
+            if (!empty($errors)) {
+                $redirect = add_query_arg('event_error', '1', $redirect);
+            }
+            wp_safe_redirect($redirect);
+            exit;
+        }
+
+        if (!empty($errors)) {
+            return new WP_Error('ap_event_submission_failed', implode(' ', $errors));
+        }
+
+        return 0;
+    }
+
+    private static function get_user_org_id(int $user_id): int
+    {
+        if ($user_id <= 0) {
+            return 0;
+        }
+
+        $owned = get_posts([
+            'post_type'      => 'artpulse_org',
+            'post_status'    => ['publish', 'draft', 'pending'],
+            'posts_per_page' => 1,
+            'meta_query'     => [
+                [
+                    'key'   => '_ap_owner_user',
+                    'value' => $user_id,
+                ],
+            ],
+        ]);
+
+        if (!empty($owned) && $owned[0] instanceof WP_Post) {
+            return (int) $owned[0]->ID;
+        }
+
+        $authored = get_posts([
+            'post_type'      => 'artpulse_org',
+            'post_status'    => ['publish', 'draft', 'pending'],
+            'posts_per_page' => 1,
+            'author'         => $user_id,
+        ]);
+
+        if (!empty($authored) && $authored[0] instanceof WP_Post) {
+            return (int) $authored[0]->ID;
+        }
+
+        return 0;
+    }
+
+    private static function remember_errors(int $user_id, array $messages): void
+    {
+        $messages = array_filter(array_map(static fn($message) => sanitize_text_field((string) $message), $messages));
+
+        $key = self::ERROR_TRANSIENT_PREFIX . $user_id;
+
+        if (empty($messages)) {
+            delete_transient($key);
+            return;
+        }
+
+        set_transient($key, $messages, MINUTE_IN_SECONDS * 5);
+    }
+
+    private static function pull_errors(int $user_id): array
+    {
+        if ($user_id <= 0) {
+            return [];
+        }
+
+        $key = self::ERROR_TRANSIENT_PREFIX . $user_id;
+        $messages = get_transient($key);
+
+        if (!is_array($messages)) {
+            return [];
+        }
+
+        delete_transient($key);
+
+        return array_map('sanitize_text_field', $messages);
+    }
+
+    private static function ensure_media_dependencies(): void
+    {
+        static $loaded = false;
+
+        if ($loaded) {
+            return;
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/media.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $loaded = true;
+    }
+
+    private static function prepare_file_array(array $file): array
+    {
+        return [
+            'name'     => isset($file['name']) ? (string) $file['name'] : '',
+            'type'     => isset($file['type']) ? (string) $file['type'] : '',
+            'tmp_name' => isset($file['tmp_name']) ? (string) $file['tmp_name'] : '',
+            'error'    => isset($file['error']) ? (int) $file['error'] : 0,
+            'size'     => isset($file['size']) ? (int) $file['size'] : 0,
+        ];
+    }
+
+    private static function validate_image_upload(array $file, string $label): ?string
+    {
+        if (!empty($file['error']) && UPLOAD_ERR_OK !== $file['error']) {
+            $message = match ((int) $file['error']) {
+                UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE => __('The file exceeds the maximum allowed size.', 'artpulse-management'),
+                UPLOAD_ERR_PARTIAL                       => __('The upload was incomplete.', 'artpulse-management'),
+                UPLOAD_ERR_NO_FILE                       => __('No file was uploaded.', 'artpulse-management'),
+                default                                  => __('The file could not be uploaded.', 'artpulse-management'),
+            };
+
+            return sprintf('%s: %s', $label, $message);
+        }
+
+        if (empty($file['tmp_name']) || !file_exists($file['tmp_name'])) {
+            return sprintf(__('Unable to read the %s.', 'artpulse-management'), strtolower($label));
+        }
+
+        if ($file['size'] > self::MAX_IMAGE_BYTES) {
+            return sprintf(
+                /* translators: 1: Field label, 2: maximum size in MB. */
+                __('%1$s must be smaller than %2$dMB.', 'artpulse-management'),
+                $label,
+                10
+            );
+        }
+
+        $check = wp_check_filetype_and_ext($file['tmp_name'], $file['name']);
+        $type = $check['type'] ?? '';
+        if ('' === $type || !in_array($type, ['image/jpeg', 'image/png', 'image/webp'], true)) {
+            return sprintf(__('%s must be a JPG, PNG, or WebP image.', 'artpulse-management'), $label);
+        }
+
+        $size = @getimagesize($file['tmp_name']); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+        if (!is_array($size) || count($size) < 2) {
+            return sprintf(__('We could not determine the dimensions of the %s.', 'artpulse-management'), strtolower($label));
+        }
+
+        [$width, $height] = $size;
+        if ($width < self::MIN_IMAGE_DIMENSION || $height < self::MIN_IMAGE_DIMENSION) {
+            return sprintf(
+                /* translators: 1: Field label, 2: minimum dimension. */
+                __('%1$s must be at least %2$d×%2$d pixels.', 'artpulse-management'),
+                $label,
+                self::MIN_IMAGE_DIMENSION
+            );
+        }
+
+        return null;
     }
 }

--- a/tests/Integration/OrganizationUpgradeFlowTest.php
+++ b/tests/Integration/OrganizationUpgradeFlowTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace ArtPulse\Tests\Integration;
+
+use ArtPulse\Admin\UpgradeReviewsController;
+use ArtPulse\Core\RoleUpgradeManager;
+use ArtPulse\Core\UpgradeReviewRepository;
+use ArtPulse\Frontend\OrgBuilderShortcode;
+use ArtPulse\Frontend\OrganizationEventForm;
+use ArtPulse\Rest\SubmissionRestController;
+use WP_Post;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class OrganizationUpgradeFlowTest extends WP_UnitTestCase
+{
+    private const JPEG_FIXTURE_BASE64 = '/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxISEhUQEhIWFRUVFRUVFRUVFRUVFRUVFRUXFhUVFRUYHSggGholGxUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGxAQGy0lICUtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIALcBEwMBIgACEQEDEQH/xAAbAAACAgMBAAAAAAAAAAAAAAABAgMEBQYAB//EADkQAAEDAgMFBgQEBQMFAQAAAAEAAhEDIQQSMUEFUWEGEyJxgZGh8BRCUrHB0fAjM2KCktLh8RZTc4KS/8QAGgEAAwEBAQEAAAAAAAAAAAAAAAECAwQFBv/EACcRAQEAAgICAwACAwEAAAAAAAABAhESITFBEyJRYXGB8AUiMv/aAAwDAQACEQMRAD8A9ziIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIP/Z';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $_POST  = [];
+        $_FILES = [];
+    }
+
+    public function test_builder_shows_pending_notice_for_pending_request(): void
+    {
+        $user_id = self::factory()->user->create(['role' => 'subscriber']);
+        $org_id  = $this->create_org_for_user($user_id, 'draft');
+
+        RoleUpgradeManager::attach_owner($org_id, $user_id);
+        UpgradeReviewRepository::create_org_upgrade($user_id, $org_id);
+
+        wp_set_current_user($user_id);
+
+        $output = OrgBuilderShortcode::render();
+
+        $this->assertStringContainsString('pending', $output);
+    }
+
+    public function test_builder_allows_owner_to_view_builder(): void
+    {
+        $user_id = self::factory()->user->create(['role' => 'organization']);
+        $org_id  = $this->create_org_for_user($user_id, 'publish');
+        RoleUpgradeManager::attach_owner($org_id, $user_id);
+
+        wp_set_current_user($user_id);
+
+        $output = OrgBuilderShortcode::render();
+
+        $this->assertStringContainsString('ap-org-builder', $output);
+    }
+
+    public function test_admin_approval_grants_role_and_sends_single_email(): void
+    {
+        $user_id = self::factory()->user->create(['role' => 'subscriber']);
+        $org_id  = $this->create_org_for_user($user_id, 'draft');
+        delete_post_meta($org_id, '_ap_owner_user');
+
+        $review_id = UpgradeReviewRepository::create_org_upgrade($user_id, $org_id);
+        $review    = get_post($review_id);
+        $this->assertInstanceOf(WP_Post::class, $review);
+
+        $mailer = tests_retrieve_phpmailer_instance();
+        $mailer->mock_sent = [];
+
+        $reflector = new \ReflectionClass(UpgradeReviewsController::class);
+        $approve   = $reflector->getMethod('approve');
+        $approve->setAccessible(true);
+        $approve->invoke(null, $review);
+
+        $updated = get_post($org_id);
+        $this->assertSame('publish', $updated->post_status);
+        $this->assertSame($user_id, (int) get_post_meta($org_id, '_ap_owner_user', true));
+
+        $user = get_user_by('id', $user_id);
+        $this->assertContains('organization', $user->roles);
+
+        $emails = array_filter($mailer->mock_sent, static fn($mail) => false !== strpos($mail['subject'], 'upgrade'));
+        $this->assertCount(1, $emails);
+        $this->assertNotEmpty(get_user_meta($user_id, '_ap_upgrade_notified_organization', true));
+    }
+
+    public function test_save_images_updates_gallery_order_and_featured_image(): void
+    {
+        if (!extension_loaded('gd') && !extension_loaded('imagick')) {
+            $this->markTestSkipped('GD/Imagick not available.');
+        }
+
+        $user_id = self::factory()->user->create(['role' => 'organization']);
+        $org_id  = $this->create_org_for_user($user_id, 'publish');
+        RoleUpgradeManager::attach_owner($org_id, $user_id);
+
+        $attachment_one = $this->create_attachment_from_fixture('gallery-one.jpg');
+        $attachment_two = $this->create_attachment_from_fixture('gallery-two.jpg');
+
+        update_post_meta($org_id, '_ap_gallery_ids', [$attachment_one, $attachment_two]);
+        set_post_thumbnail($org_id, $attachment_one);
+
+        $_POST = [
+            'existing_gallery_ids' => [$attachment_one, $attachment_two],
+            'gallery_order'        => [
+                $attachment_one => 2,
+                $attachment_two => 1,
+            ],
+            'ap_featured_image'    => (string) $attachment_two,
+        ];
+        $_FILES = [];
+
+        $reflector = new \ReflectionClass(OrgBuilderShortcode::class);
+        $method    = $reflector->getMethod('save_images');
+        $method->setAccessible(true);
+        $errors = $method->invoke(null, $org_id);
+
+        $this->assertSame([], $errors);
+        $this->assertSame([$attachment_two, $attachment_one], get_post_meta($org_id, '_ap_gallery_ids', true));
+        $this->assertSame($attachment_two, get_post_thumbnail_id($org_id));
+    }
+
+    public function test_event_form_locks_organization_to_owner(): void
+    {
+        if (!extension_loaded('gd') && !extension_loaded('imagick')) {
+            $this->markTestSkipped('GD/Imagick not available.');
+        }
+
+        $owner_id = self::factory()->user->create(['role' => 'organization']);
+        $owned_org_id = $this->create_org_for_user($owner_id, 'publish');
+        RoleUpgradeManager::attach_owner($owned_org_id, $owner_id);
+
+        $other_org_id = $this->create_org_for_user(self::factory()->user->create(), 'publish');
+
+        wp_set_current_user($owner_id);
+
+        [$temp_file, $file_size] = self::createTempFileFromBase64(self::JPEG_FIXTURE_BASE64, 'event-flyer.jpg');
+
+        $_POST = [
+            'title'          => 'Owner Event',
+            'description'    => 'Description',
+            'event_date'     => '2025-01-01',
+            'event_location' => 'Gallery Space',
+            'event_type'     => '',
+            'org_id'         => $other_org_id,
+        ];
+
+        $_FILES = [
+            'event_flyer' => [
+                'name'     => 'event-flyer.jpg',
+                'type'     => 'image/jpeg',
+                'tmp_name' => $temp_file,
+                'error'    => UPLOAD_ERR_OK,
+                'size'     => $file_size,
+            ],
+        ];
+
+        $post_id = OrganizationEventForm::handle_submission(false);
+        $this->assertIsInt($post_id);
+
+        $this->assertSame($owned_org_id, (int) get_post_meta($post_id, '_ap_event_organization', true));
+
+        if (file_exists($temp_file)) {
+            unlink($temp_file);
+        }
+    }
+
+    public function test_rest_submission_locks_event_to_owned_org(): void
+    {
+        $owner_id = self::factory()->user->create(['role' => 'organization']);
+        $owned_org_id = $this->create_org_for_user($owner_id, 'publish');
+        RoleUpgradeManager::attach_owner($owned_org_id, $owner_id);
+
+        $other_org_id = $this->create_org_for_user(self::factory()->user->create(), 'publish');
+
+        wp_set_current_user($owner_id);
+
+        $request = new WP_REST_Request('POST', '/artpulse/v1/submissions');
+        $request->set_body_params([
+            'post_type'          => 'artpulse_event',
+            'title'              => 'REST Event',
+            'content'            => 'REST body',
+            'event_date'         => '2025-02-01',
+            'event_location'     => 'Main Hall',
+            'event_organization' => $other_org_id,
+        ]);
+
+        $response = SubmissionRestController::handle_submission($request);
+
+        $this->assertNotWPError($response);
+        $data    = $response->get_data();
+        $post_id = (int) $data['id'];
+
+        $this->assertSame($owned_org_id, (int) get_post_meta($post_id, '_ap_event_organization', true));
+    }
+
+    public function test_rest_permissions_block_event_submission_without_org(): void
+    {
+        $user_id = self::factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($user_id);
+
+        $request = new WP_REST_Request('POST', '/artpulse/v1/submissions');
+        $request->set_body_params([
+            'post_type'      => 'artpulse_event',
+            'title'          => 'Unauthorized Event',
+            'event_date'     => '2025-03-01',
+            'event_location' => 'Secret Space',
+        ]);
+
+        $error = SubmissionRestController::permissions_check($request);
+        $this->assertWPError($error);
+    }
+
+    private function create_org_for_user(int $user_id, string $status = 'draft'): int
+    {
+        $org_id = self::factory()->post->create([
+            'post_type'   => 'artpulse_org',
+            'post_status' => $status,
+            'post_title'  => 'Org ' . $user_id,
+            'post_author' => $user_id,
+        ]);
+
+        return (int) $org_id;
+    }
+
+    private function create_attachment_from_fixture(string $filename): int
+    {
+        [$temp_file, $file_size] = self::createTempFileFromBase64(self::JPEG_FIXTURE_BASE64, $filename);
+
+        $upload = wp_upload_bits($filename, null, file_get_contents($temp_file));
+        $filetype = wp_check_filetype($filename);
+
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $attachment_id = wp_insert_attachment([
+            'post_mime_type' => $filetype['type'] ?? 'image/jpeg',
+            'post_title'     => sanitize_file_name($filename),
+            'post_status'    => 'inherit',
+        ], $upload['file']);
+
+        wp_update_attachment_metadata($attachment_id, wp_generate_attachment_metadata($attachment_id, $upload['file']));
+
+        if (file_exists($temp_file)) {
+            unlink($temp_file);
+        }
+
+        return (int) $attachment_id;
+    }
+
+    private static function createTempFileFromBase64(string $base64, string $filename): array
+    {
+        $data = base64_decode($base64);
+        $temp = wp_tempnam($filename);
+
+        if (false === $temp) {
+            throw new \RuntimeException('Unable to create temporary file for fixture.');
+        }
+
+        file_put_contents($temp, $data);
+
+        return [$temp, strlen($data)];
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an idempotent organization upgrade flow with guarded ownership attachment, upgrade email deduplication, and a revoke scaffold in `RoleUpgradeManager`
- secure the member dashboard, admin review table, and organization builder with capability checks, nonce validation, detailed notices, and robust image handling
- lock organization ownership on event submissions, enforce upload constraints across forms/REST, refresh the builder UI/preview, and document the end-to-end member→organization lifecycle
- add integration coverage for upgrade approvals, builder interactions, and event submissions to protect the new flows

## Testing
- `composer test` *(fails: vendor/bin/phpunit missing prior to dependency install)*
- `composer install --no-interaction` *(fails: GitHub 403 when fetching dependencies)*
- `php -l src/Frontend/OrgBuilderShortcode.php`
- `php -l src/Frontend/OrganizationEventForm.php`
- `php -l src/Rest/SubmissionRestController.php`
- `php -l tests/Integration/OrganizationUpgradeFlowTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68e60cc3533c832e9c4afc6048937bb8