### PR TITLE
Add mobile refresh tokens and rate limiting headers

### DIFF
--- a/src/Mobile/RateLimiter.php
+++ b/src/Mobile/RateLimiter.php
@@ -6,37 +6,152 @@ use WP_Error;
 
 class RateLimiter
 {
-    public static function enforce(string $bucket, int $limit = 15, int $window = 60): ?WP_Error
+    private const WINDOW = 60;
+    private const WRITE_LIMIT = 60;
+    private const READ_LIMIT = 240;
+
+    private static bool $registered = false;
+    private static ?array $pending_headers = null;
+
+    public static function register(): void
     {
-        $user_id = get_current_user_id();
-        $ip      = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
-        $key     = 'ap_rl_' . md5($bucket . '|' . $user_id . '|' . $ip);
-
-        $state = get_transient($key);
-        $now   = time();
-
-        if (!is_array($state) || empty($state['start']) || ($now - (int) $state['start']) >= $window) {
-            set_transient($key, ['start' => $now, 'count' => 1], $window);
-            return null;
+        if (self::$registered) {
+            return;
         }
 
-        $count = (int) ($state['count'] ?? 0);
-        if ($count >= $limit) {
-            $retry = $window - ($now - (int) $state['start']);
+        add_filter('rest_pre_dispatch', [self::class, 'handle_request'], 10, 3);
+        add_filter('rest_post_dispatch', [self::class, 'inject_headers'], 99, 3);
+        self::$registered = true;
+    }
+
+    /**
+     * @param mixed $result
+     * @return mixed
+     */
+    public static function handle_request($result, $server, $request)
+    {
+        if (!$request instanceof \WP_REST_Request) {
+            return $result;
+        }
+
+        if (0 !== strpos($request->get_route(), '/artpulse/v1/mobile')) {
+            return $result;
+        }
+
+        $is_write = in_array(strtoupper($request->get_method()), ['POST', 'PUT', 'PATCH', 'DELETE'], true);
+        $limit    = $is_write ? self::WRITE_LIMIT : self::READ_LIMIT;
+        $window   = self::WINDOW;
+
+        $limit  = (int) apply_filters('artpulse_mobile_rate_limit', $limit, $request, $is_write);
+        $window = (int) apply_filters('artpulse_mobile_rate_window', $window, $request, $is_write);
+
+        $bucket = ($is_write ? 'write' : 'read') . ':' . trim($request->get_route(), '/');
+
+        $error = self::enforce($bucket, $limit, $window, $request);
+        if ($error instanceof WP_Error) {
+            return $error;
+        }
+
+        return $result;
+    }
+
+    public static function enforce(string $bucket, int $limit = 15, int $window = 60, ?\WP_REST_Request $request = null): ?WP_Error
+    {
+        $now     = time();
+        $user_id = get_current_user_id();
+        $ip      = $request instanceof \WP_REST_Request ? $request->get_header('X-Forwarded-For') : '';
+        if (!$ip) {
+            $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+        } else {
+            $ip = trim(explode(',', (string) $ip)[0]);
+        }
+
+        $keys = [];
+        if ($user_id) {
+            $keys[] = 'ap_rl_u_' . md5($bucket . '|' . $user_id);
+        }
+
+        if ($ip) {
+            $keys[] = 'ap_rl_ip_' . md5($bucket . '|' . $ip);
+        }
+
+        if (empty($keys)) {
+            $keys[] = 'ap_rl_global_' . md5($bucket);
+        }
+
+        $remaining = $limit;
+        $reset_at  = $now + $window;
+        $retry_after = 0;
+
+        foreach ($keys as $key) {
+            $state = get_transient($key);
+
+            if (!is_array($state) || !isset($state['start']) || ($now - (int) $state['start']) >= $window) {
+                $state = ['start' => $now, 'count' => 0];
+            }
+
+            $reset_at = min($reset_at, (int) $state['start'] + $window);
+
+            $count = (int) ($state['count'] ?? 0);
+            if ($count >= $limit) {
+                $retry_after = max($retry_after, max(1, ($state['start'] + $window) - $now));
+                $remaining   = 0;
+                continue;
+            }
+
+            $count++;
+            $state['count'] = $count;
+            $remaining = min($remaining, max(0, $limit - $count));
+            set_transient($key, $state, $window);
+        }
+
+        self::$pending_headers = [
+            'limit'     => $limit,
+            'remaining' => max(0, $remaining),
+            'reset'     => $reset_at,
+        ];
+
+        if ($retry_after > 0) {
+            self::$pending_headers['remaining'] = 0;
+            self::$pending_headers['retry_after'] = $retry_after;
 
             return new WP_Error(
                 'ap_rate_limited',
                 __('Too many requests. Please slow down.', 'artpulse-management'),
                 [
-                    'status'     => 429,
-                    'retry_after'=> max(1, $retry),
+                    'status'      => 429,
+                    'retry_after' => $retry_after,
                 ]
             );
         }
 
-        $state['count'] = $count + 1;
-        set_transient($key, $state, $window);
-
         return null;
+    }
+
+    public static function inject_headers($response, $server, $request)
+    {
+        if (!$request instanceof \WP_REST_Request || 0 !== strpos($request->get_route(), '/artpulse/v1/mobile')) {
+            self::$pending_headers = null;
+            return $response;
+        }
+
+        if (!self::$pending_headers) {
+            return $response;
+        }
+
+        if ($response instanceof \WP_REST_Response) {
+            $headers = self::$pending_headers;
+            $response->header('X-RateLimit-Limit', (string) ($headers['limit'] ?? 0));
+            $response->header('X-RateLimit-Remaining', (string) ($headers['remaining'] ?? 0));
+            $response->header('X-RateLimit-Reset', (string) ($headers['reset'] ?? 0));
+
+            if (isset($headers['retry_after'])) {
+                $response->header('Retry-After', (string) $headers['retry_after']);
+            }
+        }
+
+        self::$pending_headers = null;
+
+        return $response;
     }
 }

--- a/src/Mobile/RefreshTokens.php
+++ b/src/Mobile/RefreshTokens.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace ArtPulse\Mobile;
+
+use WP_Error;
+
+class RefreshTokens
+{
+    private const META_KEY = 'ap_mobile_refresh_tokens';
+    private const DEFAULT_TTL = 30 * DAY_IN_SECONDS;
+    private const MAX_TOKENS = 20;
+
+    /**
+     * Mint a refresh token for the provided user and device identifier.
+     *
+     * @return array{token:string,kid:string,expires:int}
+     */
+    public static function mint(int $user_id, ?string $device_id = null, ?int $ttl = null): array
+    {
+        $device  = self::normalize_device($device_id);
+        $issued  = time();
+        $ttl     = $ttl ?? self::DEFAULT_TTL;
+        $expires = $issued + max(HOUR_IN_SECONDS, $ttl);
+
+        $kid    = wp_generate_uuid4();
+        $secret = self::generate_secret();
+        $hash   = self::hash_token($kid, $secret);
+
+        $records = self::get_records($user_id);
+        $records = self::prune_records($records, $device);
+
+        $records[] = [
+            'kid'     => $kid,
+            'hash'    => $hash,
+            'device'  => $device,
+            'expires' => $expires,
+            'issued'  => $issued,
+        ];
+
+        if (count($records) > self::MAX_TOKENS) {
+            $records = array_slice($records, -1 * self::MAX_TOKENS);
+        }
+
+        update_user_meta($user_id, self::META_KEY, array_values($records));
+
+        return [
+            'token'   => self::encode_token($kid, $user_id, $secret),
+            'kid'     => $kid,
+            'expires' => $expires,
+        ];
+    }
+
+    /**
+     * Validate a refresh token and return context for rotation.
+     *
+     * @return array{user_id:int,device_id:string,kid:string,expires:int}|WP_Error
+     */
+    public static function validate(string $refresh_token)
+    {
+        $parts = explode('.', trim($refresh_token));
+        if (3 !== count($parts)) {
+            return new WP_Error('ap_invalid_refresh', __('Invalid refresh token structure.', 'artpulse-management'), ['status' => 401]);
+        }
+
+        [$kid, $user_part, $secret] = $parts;
+
+        if (!is_numeric($user_part)) {
+            return new WP_Error('ap_invalid_refresh', __('Refresh token missing subject.', 'artpulse-management'), ['status' => 401]);
+        }
+
+        $user_id = (int) $user_part;
+        $records = self::get_records($user_id);
+        $now     = time();
+
+        foreach ($records as $index => $record) {
+            if (($record['kid'] ?? '') !== $kid) {
+                continue;
+            }
+
+            if (($record['expires'] ?? 0) < $now) {
+                unset($records[$index]);
+                update_user_meta($user_id, self::META_KEY, array_values($records));
+
+                return new WP_Error('ap_refresh_expired', __('Refresh token expired.', 'artpulse-management'), ['status' => 401]);
+            }
+
+            $expected = self::hash_token($kid, $secret);
+            if (!hash_equals((string) ($record['hash'] ?? ''), $expected)) {
+                unset($records[$index]);
+                update_user_meta($user_id, self::META_KEY, array_values($records));
+
+                return new WP_Error('ap_refresh_revoked', __('Refresh token revoked.', 'artpulse-management'), ['status' => 401]);
+            }
+
+            return [
+                'user_id'   => $user_id,
+                'device_id' => (string) ($record['device'] ?? 'unknown'),
+                'kid'       => (string) $kid,
+                'expires'   => (int) ($record['expires'] ?? $now),
+            ];
+        }
+
+        return new WP_Error('ap_refresh_revoked', __('Refresh token revoked.', 'artpulse-management'), ['status' => 401]);
+    }
+
+    /**
+     * Rotate a refresh token after successful validation.
+     *
+     * @param array{user_id:int,device_id:string,kid:string} $context
+     *
+     * @return array{token:string,kid:string,expires:int}
+     */
+    public static function rotate(array $context): array
+    {
+        $user_id  = (int) ($context['user_id'] ?? 0);
+        $device   = self::normalize_device($context['device_id'] ?? '');
+        $previous = (string) ($context['kid'] ?? '');
+
+        $records = self::get_records($user_id);
+        $records = array_values(array_filter(
+            $records,
+            static fn($record) => ($record['kid'] ?? '') !== $previous
+        ));
+        update_user_meta($user_id, self::META_KEY, $records);
+
+        return self::mint($user_id, $device);
+    }
+
+    public static function revoke_all(int $user_id): void
+    {
+        delete_user_meta($user_id, self::META_KEY);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function get_records(int $user_id): array
+    {
+        $records = get_user_meta($user_id, self::META_KEY, true);
+        if (!is_array($records)) {
+            return [];
+        }
+
+        $now = time();
+        $changed = false;
+
+        foreach ($records as $index => $record) {
+            if (($record['expires'] ?? 0) < $now) {
+                unset($records[$index]);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            update_user_meta($user_id, self::META_KEY, array_values($records));
+        }
+
+        return array_values($records);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $records
+     * @return array<int, array<string, mixed>>
+     */
+    private static function prune_records(array $records, string $device): array
+    {
+        $now = time();
+
+        $records = array_filter(
+            $records,
+            static function ($record) use ($device, $now) {
+                if (!is_array($record)) {
+                    return false;
+                }
+
+                if (($record['expires'] ?? 0) < $now) {
+                    return false;
+                }
+
+                return (string) ($record['device'] ?? '') !== $device;
+            }
+        );
+
+        return array_values($records);
+    }
+
+    private static function normalize_device(?string $device_id): string
+    {
+        $device_id = $device_id ?? '';
+        $device_id = sanitize_text_field($device_id);
+
+        if ('' === $device_id) {
+            $device_id = 'unknown';
+        }
+
+        return substr($device_id, 0, 191);
+    }
+
+    private static function generate_secret(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
+    private static function encode_token(string $kid, int $user_id, string $secret): string
+    {
+        return sprintf('%s.%d.%s', $kid, $user_id, $secret);
+    }
+
+    private static function hash_token(string $kid, string $secret): string
+    {
+        $key = wp_salt('ap_refresh');
+
+        return hash_hmac('sha256', $kid . '|' . $secret, $key);
+    }
+}

--- a/src/Mobile/RestErrorFormatter.php
+++ b/src/Mobile/RestErrorFormatter.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace ArtPulse\Mobile;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+class RestErrorFormatter
+{
+    private const STATUS_MAP = [
+        'rest_invalid_param'      => 400,
+        'rest_invalid_route'      => 404,
+        'rest_post_invalid_id'    => 404,
+        'rest_no_route'           => 404,
+        'rest_no_callback'        => 404,
+        'rest_user_cannot_view'   => 403,
+        'rest_forbidden'          => 403,
+        'rest_cannot_edit'        => 403,
+        'rest_cookie_invalid_nonce' => 403,
+        'rest_not_logged_in'      => 401,
+        'rest_invalid_token'      => 401,
+        'ap_invalid_credentials'  => 401,
+        'ap_invalid_token'        => 401,
+        'ap_missing_token'        => 401,
+        'ap_invalid_refresh'      => 401,
+        'ap_refresh_expired'      => 401,
+        'ap_refresh_revoked'      => 401,
+        'ap_rate_limited'         => 429,
+    ];
+
+    private static bool $registered = false;
+
+    public static function register(): void
+    {
+        if (self::$registered) {
+            return;
+        }
+
+        add_filter('rest_post_dispatch', [self::class, 'format'], 50, 3);
+        self::$registered = true;
+    }
+
+    /**
+     * @param WP_Error|WP_REST_Response $response
+     * @return WP_Error|WP_REST_Response
+     */
+    public static function format($response, WP_REST_Server $server, WP_REST_Request $request)
+    {
+        if (0 !== strpos($request->get_route(), '/artpulse/v1/mobile')) {
+            return $response;
+        }
+
+        if ($response instanceof WP_Error) {
+            return self::from_error($response);
+        }
+
+        if ($response instanceof WP_REST_Response) {
+            $data = $response->get_data();
+            if ($data instanceof WP_Error) {
+                return self::from_error($data);
+            }
+        }
+
+        return $response;
+    }
+
+    private static function from_error(WP_Error $error): WP_REST_Response
+    {
+        $primary_code = $error->get_error_codes()[0] ?? 'ap_error';
+        $status       = self::determine_status($error, $primary_code);
+        $message      = $error->get_error_message($primary_code);
+        $details      = self::collect_details($error);
+
+        $response = new WP_REST_Response([
+            'code'    => $primary_code,
+            'message' => $message,
+            'details' => $details,
+        ], $status);
+
+        return $response;
+    }
+
+    private static function determine_status(WP_Error $error, string $primary_code): int
+    {
+        foreach ($error->get_error_codes() as $code) {
+            $data = $error->get_error_data($code);
+            if (is_array($data) && isset($data['status'])) {
+                return (int) $data['status'];
+            }
+
+            if (is_int($data) && $data >= 100 && $data < 600) {
+                return $data;
+            }
+        }
+
+        if (isset(self::STATUS_MAP[$primary_code])) {
+            return self::STATUS_MAP[$primary_code];
+        }
+
+        foreach ($error->get_error_codes() as $code) {
+            if (isset(self::STATUS_MAP[$code])) {
+                return self::STATUS_MAP[$code];
+            }
+        }
+
+        return 400;
+    }
+
+    private static function collect_details(WP_Error $error): array
+    {
+        $details = [];
+
+        foreach ($error->get_error_codes() as $code) {
+            $messages = $error->get_error_messages($code);
+            $data     = $error->get_error_data($code);
+
+            $entry = [];
+            if (!empty($messages)) {
+                $entry['messages'] = array_values($messages);
+            }
+
+            if (is_array($data)) {
+                $entry['data'] = self::filter_status($data);
+            } elseif (null !== $data) {
+                $entry['data'] = $data;
+            }
+
+            $details[$code] = $entry;
+        }
+
+        return $details;
+    }
+
+    private static function filter_status(array $data): array
+    {
+        if (array_key_exists('status', $data)) {
+            unset($data['status']);
+        }
+
+        return $data;
+    }
+}

--- a/tests/Rest/Mobile/MobileRestControllerTest.php
+++ b/tests/Rest/Mobile/MobileRestControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Rest\Mobile;
 use ArtPulse\Mobile\EventGeo;
 use ArtPulse\Mobile\FollowService;
 use ArtPulse\Mobile\JWT;
+use ArtPulse\Mobile\RefreshTokens;
 use WP_REST_Request;
 use WP_UnitTestCase;
 
@@ -17,14 +18,19 @@ class MobileRestControllerTest extends WP_UnitTestCase
     {
         parent::set_up();
 
+        global $wpdb;
+        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_ap_rl_%' OR option_name LIKE '_transient_timeout_ap_rl_%'");
+
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
         \ArtPulse\Mobile\EventInteractions::install_tables();
         FollowService::install_table();
         EventGeo::install_table();
 
         $this->user_id = $this->factory->user->create([
-            'role'      => 'subscriber',
-            'user_login'=> 'mobile-user',
-            'user_pass' => $this->password,
+            'role'       => 'subscriber',
+            'user_login' => 'mobile-user',
+            'user_pass'  => $this->password,
         ]);
 
         wp_set_password($this->password, $this->user_id);
@@ -39,6 +45,7 @@ class MobileRestControllerTest extends WP_UnitTestCase
             'username'   => 'mobile-user',
             'password'   => $this->password,
             'push_token' => 'device-token-123',
+            'device_id'  => 'ios-device-1',
         ]);
 
         $response = rest_do_request($request);
@@ -46,8 +53,72 @@ class MobileRestControllerTest extends WP_UnitTestCase
 
         $data = $response->get_data();
         $this->assertArrayHasKey('token', $data);
+        $this->assertArrayHasKey('refreshToken', $data);
+        $this->assertArrayHasKey('refreshExpires', $data);
         $this->assertArrayHasKey('user', $data);
         $this->assertSame('device-token-123', get_user_meta($this->user_id, 'ap_mobile_push_token', true));
+    }
+
+    public function test_refresh_rotates_and_invalidates_previous_token(): void
+    {
+        $login = new WP_REST_Request('POST', '/artpulse/v1/mobile/login');
+        $login->set_body_params([
+            'username'  => 'mobile-user',
+            'password'  => $this->password,
+            'device_id' => 'android-device',
+        ]);
+
+        $login_response = rest_do_request($login);
+        $this->assertSame(200, $login_response->get_status());
+        $refresh_token = $login_response->get_data()['refreshToken'];
+
+        $refresh = new WP_REST_Request('POST', '/artpulse/v1/mobile/auth/refresh');
+        $refresh->set_body_params([
+            'refresh_token' => $refresh_token,
+        ]);
+
+        $refresh_response = rest_do_request($refresh);
+        $this->assertSame(200, $refresh_response->get_status());
+        $refresh_data = $refresh_response->get_data();
+        $this->assertNotSame($refresh_token, $refresh_data['refreshToken']);
+
+        $second = rest_do_request($refresh);
+        $this->assertSame(401, $second->get_status());
+        $this->assertSame('ap_refresh_revoked', $second->get_data()['code']);
+    }
+
+    public function test_refresh_rejects_expired_token(): void
+    {
+        $token = RefreshTokens::mint($this->user_id, 'test-device');
+
+        $records = get_user_meta($this->user_id, 'ap_mobile_refresh_tokens', true);
+        $this->assertIsArray($records);
+        $records[0]['expires'] = time() - HOUR_IN_SECONDS;
+        update_user_meta($this->user_id, 'ap_mobile_refresh_tokens', $records);
+
+        $request = new WP_REST_Request('POST', '/artpulse/v1/mobile/auth/refresh');
+        $request->set_body_params([
+            'refresh_token' => $token['token'],
+        ]);
+
+        $response = rest_do_request($request);
+        $this->assertSame(401, $response->get_status());
+        $this->assertSame('ap_refresh_expired', $response->get_data()['code']);
+    }
+
+    public function test_refresh_rejects_unknown_user(): void
+    {
+        $token = RefreshTokens::mint($this->user_id, 'test-device');
+        wp_delete_user($this->user_id);
+
+        $request = new WP_REST_Request('POST', '/artpulse/v1/mobile/auth/refresh');
+        $request->set_body_params([
+            'refresh_token' => $token['token'],
+        ]);
+
+        $response = rest_do_request($request);
+        $this->assertSame(401, $response->get_status());
+        $this->assertSame('ap_invalid_refresh', $response->get_data()['code']);
     }
 
     public function test_like_event_is_idempotent_and_counts_update(): void
@@ -127,6 +198,65 @@ class MobileRestControllerTest extends WP_UnitTestCase
         $this->assertCount(2, $data['events']);
         $this->assertSame($near_event, $data['events'][0]['id']);
         $this->assertSame($far_event, $data['events'][1]['id']);
+        $this->assertNotNull($data['events'][0]['distance_m']);
+        $this->assertGreaterThan(0, $data['events'][1]['distance_m']);
+    }
+
+    public function test_geosearch_with_bounds_filters_results(): void
+    {
+        $inside_one = wp_insert_post([
+            'post_type'   => 'artpulse_event',
+            'post_status' => 'publish',
+            'post_title'  => 'Inside One',
+        ]);
+        update_post_meta($inside_one, '_ap_event_start', gmdate('c', strtotime('+1 day')));
+        update_post_meta($inside_one, '_ap_event_location', 'Inside Hall');
+        update_post_meta($inside_one, '_ap_event_latitude', '40.0');
+        update_post_meta($inside_one, '_ap_event_longitude', '-70.0');
+        EventGeo::sync($inside_one);
+
+        $inside_two = wp_insert_post([
+            'post_type'   => 'artpulse_event',
+            'post_status' => 'publish',
+            'post_title'  => 'Inside Two',
+        ]);
+        update_post_meta($inside_two, '_ap_event_start', gmdate('c', strtotime('+2 day')));
+        update_post_meta($inside_two, '_ap_event_location', 'Inside Hall 2');
+        update_post_meta($inside_two, '_ap_event_latitude', '40.5');
+        update_post_meta($inside_two, '_ap_event_longitude', '-70.4');
+        EventGeo::sync($inside_two);
+
+        $outside = wp_insert_post([
+            'post_type'   => 'artpulse_event',
+            'post_status' => 'publish',
+            'post_title'  => 'Outside',
+        ]);
+        update_post_meta($outside, '_ap_event_start', gmdate('c', strtotime('+3 day')));
+        update_post_meta($outside, '_ap_event_location', 'Outside Hall');
+        update_post_meta($outside, '_ap_event_latitude', '45.0');
+        update_post_meta($outside, '_ap_event_longitude', '-80.0');
+        EventGeo::sync($outside);
+
+        $token = JWT::issue($this->user_id)['token'];
+
+        $request = new WP_REST_Request('GET', '/artpulse/v1/mobile/events');
+        $request->set_param('bounds', '39.5,-70.5,41.0,-69.5');
+        $request->set_param('limit', 10);
+        $request->set_header('Authorization', 'Bearer ' . $token);
+
+        $response = rest_do_request($request);
+        $this->assertSame(200, $response->get_status());
+        $data = $response->get_data();
+
+        $this->assertCount(2, $data['events']);
+        $ids = wp_list_pluck($data['events'], 'id');
+        $this->assertContains($inside_one, $ids);
+        $this->assertContains($inside_two, $ids);
+        $this->assertNotContains($outside, $ids);
+        foreach ($data['events'] as $event) {
+            $this->assertArrayHasKey('distance_m', $event);
+            $this->assertIsInt($event['distance_m']);
+        }
     }
 
     public function test_feed_returns_followed_org_events(): void
@@ -161,5 +291,58 @@ class MobileRestControllerTest extends WP_UnitTestCase
         $ids  = wp_list_pluck($data['events'], 'id');
 
         $this->assertContains($event_id, $ids);
+    }
+
+    public function test_rate_limiter_returns_headers_and_429(): void
+    {
+        $event_id = wp_insert_post([
+            'post_type'   => 'artpulse_event',
+            'post_status' => 'publish',
+            'post_title'  => 'Rate Event',
+        ]);
+
+        add_filter('artpulse_mobile_rate_limit', static function ($limit, $request, $is_write) {
+            if ($is_write && $request instanceof WP_REST_Request && false !== strpos($request->get_route(), '/mobile/events')) {
+                return 2;
+            }
+
+            return $limit;
+        }, 10, 3);
+
+        try {
+            $token = JWT::issue($this->user_id)['token'];
+
+            $request = new WP_REST_Request('POST', '/artpulse/v1/mobile/events/' . $event_id . '/like');
+            $request->set_header('Authorization', 'Bearer ' . $token);
+
+            $first  = rest_do_request($request);
+            $second = rest_do_request($request);
+
+            $this->assertSame(200, $first->get_status());
+            $this->assertSame(200, $second->get_status());
+
+            $third = rest_do_request($request);
+            $this->assertSame(429, $third->get_status());
+
+            $headers = array_change_key_case($third->get_headers(), CASE_LOWER);
+            $this->assertSame('2', $headers['x-ratelimit-limit'] ?? null);
+            $this->assertSame('0', $headers['x-ratelimit-remaining'] ?? null);
+            $this->assertArrayHasKey('retry-after', $headers);
+        } finally {
+            remove_all_filters('artpulse_mobile_rate_limit');
+            remove_all_filters('artpulse_mobile_rate_window');
+        }
+    }
+
+    public function test_error_responses_are_standardized(): void
+    {
+        $request = new WP_REST_Request('GET', '/artpulse/v1/mobile/me');
+        $response = rest_do_request($request);
+
+        $this->assertSame(401, $response->get_status());
+        $data = $response->get_data();
+        $this->assertSame(['code', 'message', 'details'], array_keys($data));
+        $this->assertArrayHasKey('ap_missing_token', $data['details']);
+        $this->assertNotEmpty($data['details']['ap_missing_token']['messages']);
     }
 }


### PR DESCRIPTION
## Summary
- add a mobile refresh endpoint with rotating per-device tokens and wire the login response to return refresh metadata
- implement route-aware rate limiting headers with IP fallbacks plus uniform mobile error formatting
- support bounding-box event queries and expand mobile REST integration coverage for refresh, limits, and errors

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `composer install` *(fails: GitHub API 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e67e758b08832e9a8b7c62f6931ef8